### PR TITLE
The Iowa Shibboleth referrer is /idp/profile/SAML2/Redirect/SSO?back=true 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,8 @@ class ApplicationController < ActionController::Base
     request_url = request_url.split('?').first if request_url # take off the GET parameters unless nil
 
     # add to history if we are not going back, request is html, it's not the sign in page, and we aren't going to the same page that we are currently on
-    if !params[:back] && request.format.to_sym === :html && (referrer && referrer.exclude?('sign_in') && referrer.exclude?('shibboleth')) && referrer != request_url
+    # The Iowa Shibboleth referrer is /idp/profile/SAML2/Redirect/SSO?back=true so we added "SAML2" to the list of referrer's to exclude.
+    if !params[:back] && request.format.to_sym === :html && (referrer && referrer.exclude?('sign_in') && referrer.exclude?('shibboleth') && referrer.exclude?('SAML2')) && referrer != request_url
       session[:breadcrumbs].push(referrer)
     elsif params[:back]
       session[:breadcrumbs].pop # remove last element if we are going back

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
       puts "#"*20
       puts e.message
       puts "#"*20
-      return "/" # default to home page.
+      return url
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
       puts "#"*20
       puts e.message
       puts "#"*20
-      return url
+      return "/" # default to home page.
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
         klass = h[:controller].classify.constantize
         klass.title h[:id]
       else
-        url
+        "/" # default to home page so shibboleth authentication redirects don't link back to shibboleth URL
       end
     rescue Exception => e
       puts "#"*20

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
         klass = h[:controller].classify.constantize
         klass.title h[:id]
       else
-        "/" # default to home page so shibboleth authentication redirects don't link back to shibboleth URL
+        url
       end
     rescue Exception => e
       puts "#"*20


### PR DESCRIPTION
...so we added "SAML2" to the list of referrer's to exclude.