### PR TITLE
Use the latest rendering mode for IE

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,6 +2,7 @@
 %html{ lang: 'en' }
   %head
     %meta{ charset: 'utf-8' }
+    %meta{ "http-equiv"=>"X-UA-Compatible", "content"=>"IE=edge"}
     %title= t('default_title') 
     :javascript
       window.I18n = #{current_translations.to_json.html_safe}


### PR DESCRIPTION
At Iowa, our Internet Explorers default to version 7 mode and this meta tag forces IE to use the rendering mode of its version #, so IE 9 will run version 9 instead of version 7. More info here: http://getbootstrap.com/getting-started/#support-ie-compatibility-modes 