### PR TITLE
Moved session storage from cookie to database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'omniauth-shibboleth'
 gem 'activerecord-import'
+gem 'activerecord-session_store'
 gem 'acts_as_list'
 gem 'addressable'
 gem 'ar-octopus', '~> 0.8.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,10 @@ GEM
       arel (~> 6.0)
     activerecord-import (0.8.0)
       activerecord (>= 3.0)
+    activerecord-session_store (0.1.2)
+      actionpack (>= 4.0.0, < 5)
+      activerecord (>= 4.0.0, < 5)
+      railties (>= 4.0.0, < 5)
     activesupport (4.2.2)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -401,6 +405,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
+  activerecord-session_store
   acts_as_list
   addressable
   ar-octopus (~> 0.8.5)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_clinical_work_fulfillment_session'
+Rails.application.config.session_store :active_record_store, :key => '_clinical_work_fulfillment_session'

--- a/db/migrate/20151207203943_add_sessions_table.rb
+++ b/db/migrate/20151207203943_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end


### PR DESCRIPTION
We were getting "ActionDispatch::Cookies::CookieOverflow" errors and assumed that they were caused by the cookies being too big. Thus, we moved session storage to the database (similar to sparc-request).