### PR TITLE
Moved 'All' to top of statuses list to support Faye refresh

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,8 +318,8 @@ en:
 
   sub_service_request:
     statuses:
-      administrative_review: 'Administrative Review'
       all: 'All'
+      administrative_review: 'Administrative Review'
       approved: 'Approved'
       awaiting_pi_approval: 'Awaiting Requester Response'
       committee_review: 'In Committee Review'


### PR DESCRIPTION
On the fulfillment home page, the default status selection used to be "All". After Alphabetizing "administrative_review" above "all" in en.yml, the administrative_review is now the default status in the select box but the page still initially displays "all" requests: 
sub_service_request: 
statuses: 
administrative_review: 'Administrative Review' 
all: 'All' 

However, when faye receives an update it refreshes the grid to only shows requests with a status of administrative_review (since that is what is selected by default); which likely clears the screen for most users, that is unless the user had previously changed the status to "All". Thus, I think we should update en.yml to list "All" ahead of "administrative_review".