### PR TITLE
Prevent duplicate users in select lists for Tasks and Procedures

### DIFF
--- a/app/controllers/procedures_controller.rb
+++ b/app/controllers/procedures_controller.rb
@@ -24,7 +24,7 @@ class ProceduresController < ApplicationController
 
   def edit
     @task = Task.new
-    @clinical_providers = ClinicalProvider.where(organization_id: current_identity.protocols.map{|p| p.sub_service_request.organization_id })
+    @clinical_providers = ClinicalProvider.where(organization_id: current_identity.protocols.map{|p| p.sub_service_request.organization_id }).index_by {|cp| cp[:identity_id]}.values
     if params[:partial].present?
       @note = @procedure.notes.new(kind: 'reason')
       render params[:partial]

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -24,7 +24,7 @@ class TasksController < ApplicationController
     respond_to do |format|
       format.js {
         @task = Task.new
-        @clinical_providers = ClinicalProvider.where(organization_id: current_identity.protocols.map{|p| p.sub_service_request.organization_id })
+        @clinical_providers = ClinicalProvider.where(organization_id: current_identity.protocols.map{|p| p.sub_service_request.organization_id }).index_by {|cp| cp[:identity_id]}.values
       }
     end
   end


### PR DESCRIPTION
The following query exists in two places and will return duplicate users if the authenticated user is a clinical provider for more than one organization. This query should return a set (with no duplicates): ClinicalProvider.where(organization_id: current_identity.protocols.map{|p| p.sub_service_request.organization_id }).

I've implemented the fix but was unable to get the RSpec tests to mock data such that the following query would return results: 
Organization.protocols, method: 
  Protocol.joins(:sub_service_request).where(sub_service_requests: { organization_id: id }) 

Any tips for setting that up?