### PR TITLE
KG SW - Inactive Services Label on Procedures (2.2.0)

### DIFF
--- a/app/assets/stylesheets/participants.sass
+++ b/app/assets/stylesheets/participants.sass
@@ -159,5 +159,10 @@ body.participants
                   &.name
                     text-align: left
 
+                    .inactive-service
+                      color: red
+                      font-weight: bold
+                      font-style: italic
+
                     &.muted
                       color: rgba(119, 119, 119, 0.49)

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -11,20 +11,24 @@ module AppointmentHelper
     old_statuses
   end
 
-  def app_add_as_last_option appointment
+  def app_add_as_last_option(appointment)
     content_tag(:option, "Add as last", value: Appointment.where(arm_id: appointment.arm_id, participant_id: appointment.participant_id).size + 1)
   end
 
-  def appointment_notes_formatter appointment
+  def appointment_notes_formatter(appointment)
     notes_button({object: appointment, 
                   title: t(:appointment)[:notes], 
                   has_notes: appointment.notes.any?})
   end
 
-  def procedure_notes_formatter procedure
+  def procedure_notes_formatter(procedure)
     notes_button({object: procedure, 
                   title: t(:participant)[:notes], 
                   has_notes: procedure.notes.any?, 
                   button_class: "#{procedure.appt_started? ? '' : 'disabled'}"})
+  end
+
+  def procedure_service_name_display(service)
+    content_tag(:span, service.name) + (service.is_available ? "" : content_tag(:span, " (Inactive)", class: 'inactive-service'))
   end
 end

--- a/app/views/appointments/_procedure.html.haml
+++ b/app/views/appointments/_procedure.html.haml
@@ -1,6 +1,6 @@
 %tr.procedure.new_service{ data: { id: procedure.id, service_id: procedure.service_id, billing_type: procedure.billing_type, group_id: procedure.group_id } }
   %td.name
-    %span= procedure.service_name
+    = procedure_service_name_display(procedure.service)
   %td.billing
     = select_tag "quantity_type_#{procedure.id}", options_for_select(Procedure.billing_display, procedure.billing_type), class: "form-control billing_type selectpicker"
   %td.status

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_views_unavailable_service_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_views_unavailable_service_procedure_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+feature 'User views procedure which has an unavailable service', js: true do
+
+	scenario 'and sees the inactive tag' do
+		given_i_am_viewing_the_appointment_calendar
+		when_the_participant_has_a_procedure_with_an_inactive_service
+		when_i_open_the_appointment_calendar_with_the_bad_procedure
+		then_i_should_see_the_inactive_tag
+	end
+
+	def given_i_am_viewing_the_appointment_calendar
+		protocol 		= create_and_assign_protocol_to_me
+		@participant = protocol.participants.first
+
+		visit participant_path(@participant)
+		wait_for_ajax
+	end
+
+	def when_the_participant_has_a_procedure_with_an_inactive_service
+		service     = Service.first
+		@appointment = @participant.appointments.first
+
+		service.update_attributes(is_available: false)
+
+		create(:procedure, appointment: @appointment, service: service)
+	end
+
+	def when_i_open_the_appointment_calendar_with_the_bad_procedure
+		visit_group_name = @appointment.visit_group.name
+
+		bootstrap_select '#appointment_select', visit_group_name
+	end
+
+	def then_i_should_see_the_inactive_tag
+		expect(page).to have_text("(Inactive)")
+	end
+end

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_views_unavailable_service_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_views_unavailable_service_procedure_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'User views procedure which has an unavailable service', js: true do
 
-	scenario 'and sees the inactive tag' do
+	scenario 'and sees the inactive tag.' do
 		given_i_am_viewing_the_appointment_calendar
 		when_the_participant_has_a_procedure_with_an_inactive_service
 		when_i_open_the_appointment_calendar_with_the_bad_procedure


### PR DESCRIPTION
Adds a red-texted span tag with text "(Inactive)" next to the service name for procedures whose service is now inactive