### PR TITLE
WTH - Fulfillment Participant Tracker Reconfiguration

### DIFF
--- a/app/assets/javascripts/participants.js.coffee
+++ b/app/assets/javascripts/participants.js.coffee
@@ -1,5 +1,10 @@
 $ ->
 
+  $('#completed-appointments-table').on 'click-row.bs.table', (row, $element) ->
+    $.ajax
+      type: 'GET'
+      url: "/appointments/#{$element.id}.js"
+
   $(document).on 'click', '.new-participant', ->
     data =
       'protocol_id' : $(this).data('protocol-id')

--- a/app/helpers/participant_helper.rb
+++ b/app/helpers/participant_helper.rb
@@ -1,7 +1,7 @@
 module ParticipantHelper
   def appointments_for_select arm, participant
     appointments = []
-    participant.appointments.each do |appt|
+    participant.appointments.incompleted.each do |appt|
       if appt.arm.name == arm.name
         appointments << appt
       end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -22,6 +22,7 @@ class Appointment < ActiveRecord::Base
   has_many :notes, as: :notable
 
   scope :completed, -> { where('completed_date IS NOT NULL') }
+  scope :incompleted, -> { where('appointments.completed_date IS NULL') }
   scope :unstarted, -> { where('appointments.start_date IS NULL AND appointments.completed_date IS NULL') }
   scope :with_completed_procedures, -> { joins(:procedures).where("procedures.completed_date IS NOT NULL") }
 

--- a/app/views/appointments/completed_appointments.json.jbuilder
+++ b/app/views/appointments/completed_appointments.json.jbuilder
@@ -1,4 +1,5 @@
 json.(@appointments) do |appointment|
+  json.id appointment.id
   json.name appointment.name
   json.completed_date appointment.completed_date.strftime('%x')
   json.arm appointment.arm.name

--- a/spec/features/appointments/appointment_calendar/appointment_management/identity_starts_and_completes_appointment_spec.rb
+++ b/spec/features/appointments/appointment_calendar/appointment_management/identity_starts_and_completes_appointment_spec.rb
@@ -14,7 +14,7 @@ feature 'Start Complete Buttons', js: true do
     scenario 'and sees the start date picker and the completed button active' do
       given_i_am_viewing_an_appointment
       given_there_is_a_start_date
-      when_i_load_the_page
+      when_i_load_the_page_and_select_a_visit
       then_i_should_see_the_start_datepicker
       then_i_should_see_the_complete_button
     end
@@ -43,7 +43,7 @@ feature 'Start Complete Buttons', js: true do
     scenario 'and sees the start date picker and the completed datepicker' do
       given_i_am_viewing_an_appointment
       given_there_is_a_start_date
-      when_i_load_the_page
+      when_i_load_the_page_and_select_a_visit
       when_i_click_the_complete_button
       then_i_should_see_the_start_datepicker
       then_i_should_see_the_completed_datepicker
@@ -70,7 +70,7 @@ feature 'Start Complete Buttons', js: true do
 
       given_i_am_viewing_an_appointment
       given_there_is_a_start_date
-      when_i_load_the_page
+      when_i_load_the_page_and_select_a_visit
       when_i_set_the_start_date_to future
       when_i_click_the_complete_button
       then_i_should_see_the_completed_date_at future
@@ -106,6 +106,12 @@ feature 'Start Complete Buttons', js: true do
   end
 
   def when_i_load_the_page
+    visit current_path
+    find('#completed-appointments-table tr', text: @visit_group.name).click
+    wait_for_ajax
+  end
+
+  def when_i_load_the_page_and_select_a_visit
     visit current_path
     bootstrap_select '#appointment_select', @visit_group.name
     wait_for_ajax


### PR DESCRIPTION
In the Fulfillment Participant tracker when clicking into the calendar, I made the list of completed visits clickable. Then in the select
dropdown, a user can only select visits that have not been started or
visits that are currently in progress. The other changes you will find
in this pull request are spec modifications that were required with this
reconfiguration.