### PR TITLE
wth - (SPARCFulfillment) Make the Klok Import Resource Format Rule St…

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -40,19 +40,21 @@ class ImportsController < ApplicationController
     respond_to do |format|
       if import.save
         import.update_attribute(:title, determine_if_proof_report ? I18n.t('imports.proof_report_submit') : I18n.t('imports.klok_report_submit'))
-        log_file, valid = import.generate(import.xml_file, determine_if_proof_report)
-        import.update_attribute(:file, File.open(log_file))
-        @valid = valid
-        if @valid
-          format.js
-          format.html { redirect_to imports_path }
-        else
-          import.destroy
-          format.js
+        begin
+          log_file, valid = import.generate(import.xml_file, determine_if_proof_report)
+          import.update_attribute(:file, File.open(log_file))
+          @valid = valid
+          if @valid
+            format.js
+            format.html { redirect_to imports_path }
+          else
+            import.destroy
+            format.js
+          end
+        rescue
+          format.js { render js: "swal('Improper Klok Format', 'Klok File is improperly formatted, name must be formatted as - Name (NetId)', 'error');" }
+          format.html { render :new }
         end
-      else
-        format.js
-        format.html { render :new }
       end
     end
   end

--- a/app/models/klok/person.rb
+++ b/app/models/klok/person.rb
@@ -27,9 +27,13 @@ class Klok::Person < ActiveRecord::Base
   has_many :klok_projects, class_name: 'Klok::Project', foreign_key: :resource_id, through: :klok_entries
 
   def local_identity
-    ldap_uid = name.split(" ").last.gsub(/[\(\)]*/, '')
-    ldap_uid += "@musc.edu" #### TODO, update Klok so that @musc.edu is added
-    Identity.where(ldap_uid: ldap_uid).first
-  end 
-
+    if name.match(/\([^()]*\)(?![^\[]*])/).nil?
+      ldap_uid = name.split(" ").last.gsub(/[\(\)]*/, '')
+      ldap_uid += "@musc.edu" #### TODO, update Klok so that @musc.edu is added
+      Identity.where(ldap_uid: ldap_uid).first
+    else
+      raise StandardError, "Improper Format"
+    end
+  end
 end
+


### PR DESCRIPTION
…ricter

Please make the importing rule for Klok resource to be stricter, so that the ones do not follow the format of  ******(*** ) would error out and also cause the Klok entries to error out and show up in the proof report and import report.

Currently, klok/person.rb is extracting NetID from people.name inside the brackets, however, when there are no brackets, the last word of people.name is used as the NetID. That's causing issues because there could be a lot of people with the same last name and we are grabbing the wrong person for fulfillment.

[#147196653]

Story - https://www.pivotaltracker.com/story/show/147196653