### PR TITLE
wth - (SPARCFulfillment) Order the List of Clinical Providers

### DIFF
--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -36,7 +36,7 @@
             .form-group
               = f.label "assignee_id", t(:task)[:assignee_name]+t(:actions)[:required], class: "col-sm-4 control-label"
               .col-sm-7
-                = f.select :assignee_id, options_from_collection_for_select(clinical_providers.map(&:identity), 'id', 'full_name'), { include_blank: true }, class: "form-control selectpicker"
+                = f.select :assignee_id, options_from_collection_for_select(clinical_providers.map(&:identity).sort_by!{ |i| i.last_name.downcase }.uniq, 'id', 'full_name'), { include_blank: true }, class: "form-control selectpicker"
             .form-group
               = f.label "follow_up_date", t(:task)[:due_at]+t(:actions)[:required], class: "col-sm-4 control-label"
               .col-sm-7


### PR DESCRIPTION
When assigning tasks to clinical providers from the "All Task" tab in SPARCFulfillment, or assign a clinical provider for the followup procedure, the list is out of order and showing duplicated people, as shown in attached screenshots.

Please 1). make the display of clinical providers unique;
2). display the list of names alphabetically.

[#152158482]

Story - https://www.pivotaltracker.com/story/show/152158482