### PR TITLE
wth - (SPARCFulfillment) Participant Tracker: Add New Type of Visit

### DIFF
--- a/app/views/appointments/_visit_type_dropdown.html.haml
+++ b/app/views/appointments/_visit_type_dropdown.html.haml
@@ -23,3 +23,4 @@
   %option{value: ""} Select if Applicable
   %option{value: "Lab Only"} Lab Only
   %option{value: "Space Only"} Space Only
+  %option{value: "PFT Only"} PFT Only


### PR DESCRIPTION
Inside Participant tracker, under the chosen visit, please add a new option "PFT Only" onto the dropdown list for the clinical provider to chose from.

Note: PFT  = Pulmonary Function Testing. This is requested by the users to differentiate types of visit more. The blank ones (visits with no type chosen) would be combination of more than 1 type.

[#152254452]

Story - https://www.pivotaltracker.com/story/show/152254452