### PR TITLE
ENV.fetch apparantly not working with dotenv

### DIFF
--- a/app/assets/javascripts/faye.coffee.erb
+++ b/app/assets/javascripts/faye.coffee.erb
@@ -20,8 +20,8 @@
 
 $ ->
   unless <%= Rails.env.test? %>
-    host    = "<%= ENV.fetch('CWF_FAYE_HOST') %>"
-    scheme  = "<%= ENV.fetch('GLOBAL_SCHEME') %>"
+    host    = "<%= ENV['CWF_FAYE_HOST'] %>"
+    scheme  = "<%= ENV['GLOBAL_SCHEME'] %>"
     faye    = new Faye.Client("#{scheme}://#{host}/faye")
 
     faye.disable('websocket')


### PR DESCRIPTION
Mysteriously, ENV.fetch('key') not working, ENV['key'] working

I have set .env

CWF_FAYE_HOST="fulfillment-training.ccts.utah.edu:9292"

in `faye.coffee.erb`
in the case of 
`host    = "<%= ENV['CWF_FAYE_HOST'] %>"`
will return fulfillment-training.ccts.utah.edu:9292

in the case of 
`host    = "<%= ENV.fetch('CWF_FAYE_HOST') %>"`
with return ""