### PR TITLE
wth - (SPARCFulfillment) Users should be Able to Delete Individual Fu…

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -64,3 +64,4 @@
 //= require faye
 //= require visit_group_form
 //= require imports
+//= require fulfillments

--- a/app/assets/javascripts/fulfillments.coffee
+++ b/app/assets/javascripts/fulfillments.coffee
@@ -1,0 +1,6 @@
+$ ->
+  $(document).on 'click', '.otf_fulfillment_delete', ->
+    $.ajax
+      type: 'delete'
+      url: "/fulfillments/#{$(this).data('id')}.js"
+

--- a/app/controllers/fulfillments_controller.rb
+++ b/app/controllers/fulfillments_controller.rb
@@ -71,6 +71,14 @@ class FulfillmentsController < ApplicationController
     end
   end
 
+  def destroy
+    @fulfillment = Fulfillment.find(params[:id])
+    @fulfillment.destroy
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def persist_original_attributes_to_track_changes

--- a/app/helpers/study_level_activities_helper.rb
+++ b/app/helpers/study_level_activities_helper.rb
@@ -75,6 +75,9 @@ module StudyLevelActivitiesHelper
       )+
       content_tag(:li, raw(
         content_tag(:button, raw(content_tag(:span, '', class: "glyphicon glyphicon-edit", aria: {hidden: "true"}))+' Edit Fulfillment', type: 'button', class: 'btn btn-default form-control actions-button otf_fulfillment_edit'))
+      )+
+      content_tag(:li, raw(
+                    content_tag(:button, raw(content_tag(:span, '', class: "glyphicon glyphicon-remove", aria: {hidden: "true"}))+' Delete Fulfillment', type: 'button', class: 'btn btn-default form-control actions-button otf_fulfillment_delete', data: { id: fulfillment.id }))
       )
     )
 

--- a/app/views/fulfillments/destroy.js.coffee
+++ b/app/views/fulfillments/destroy.js.coffee
@@ -1,0 +1,1 @@
+$('#fulfillments-table').bootstrapTable('refresh')


### PR DESCRIPTION
…lfillment

Scenario: When a user has a non-clinical service wrongly fulfilled in SPARCFulfillment, there is currently no way to delete the individual fulfillment, or the service (because the validation checks whether the line item has fulfillments on it).

Please add the functionality on the fulfillment popup window "Activity" dropdown menu, for users to be able to delete an individual fulfillment, (and do NOT change the logic for validation).

[#154247222]

Story - https://www.pivotaltracker.com/story/show/154247222