### PR TITLE
Rails 5 upgrade issues

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -15,6 +15,10 @@ require 'capistrano/deploy'
 #   https://github.com/capistrano/rails
 #   https://github.com/capistrano/passenger
 #
+
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
 require 'capistrano/rvm'
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,8 @@ module ClinicalWorkFulfillment
     # config.i18n.default_locale = :de
     config.time_zone = ENV.fetch('APPLICATION_TIME_ZONE')
 
+    config.eager_load_paths << Rails.root.join('lib')
+
     config.paths.add File.join('app', 'jobs'), glob: File.join('**', '*.rb')
     config.autoload_paths += Dir[Rails.root.join('app', 'jobs', '*')]
     config.paths.add File.join('lib'), glob: File.join('**', '*.rb')

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,8 +30,8 @@ set :repo_url, 'git@github.com:bmic-development/sparc-fulfillment.git'
 # Default deploy_to directory is /var/www/my_app_name
 set :deploy_to, '/var/www/rails/fulfillment'
 
-# Default value for :scm is :git
-set :scm, :git
+# Default value for :scm is :git - Depreciation notice from capistrano
+#set :scm, :git
 
 # Default value for :format is :pretty
 # set :format, :pretty


### PR DESCRIPTION
1. rails 5 disables autoloading after booting the app in production.
2. Deprecation Notice from capistrano deployment:
     To ensure your project is compatible with future versions of Capistrano,
     remove the :scm setting and instead add these lines to your Capfile after
     `require "capistrano/deploy"`:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git