### PR TITLE
SJ - Removing arm_id data from OTF line_items [#155263353]

### DIFF
--- a/db/migrate/20180219185258_remove_arm_id_data_from_otf_line_items.rb
+++ b/db/migrate/20180219185258_remove_arm_id_data_from_otf_line_items.rb
@@ -1,6 +1,6 @@
 class RemoveArmIdDataFromOtfLineItems < ActiveRecord::Migration[5.0]
   def change
-    LineItem.includes(:service).where(service: {one_time_fee: true}).where.not(arm_id: nil).each do |line_item|
+    LineItem.includes(:service).where(services: {one_time_fee: true}).where.not(arm_id: nil).each do |line_item|
       line_item.arm_id = nil
       line_item.save(validate: false)
     end

--- a/db/migrate/20180219185258_remove_arm_id_data_from_otf_line_items.rb
+++ b/db/migrate/20180219185258_remove_arm_id_data_from_otf_line_items.rb
@@ -1,8 +1,8 @@
 class RemoveArmIdDataFromOtfLineItems < ActiveRecord::Migration[5.0]
   def change
-  	LineItem.includes(:service).where(service: {one_time_fee: true}).where.not(arm_id: nil).each do |line_item|
-  		line_item.arm_id = nil
-  		line_item.save(validate: false)
-  	end
+    LineItem.includes(:service).where(service: {one_time_fee: true}).where.not(arm_id: nil).each do |line_item|
+      line_item.arm_id = nil
+      line_item.save(validate: false)
+    end
   end
 end

--- a/db/migrate/20180219185258_remove_arm_id_data_from_otf_line_items.rb
+++ b/db/migrate/20180219185258_remove_arm_id_data_from_otf_line_items.rb
@@ -1,0 +1,8 @@
+class RemoveArmIdDataFromOtfLineItems < ActiveRecord::Migration[5.0]
+  def change
+  	LineItem.includes(:service).where(service: {one_time_fee: true}).where.not(arm_id: nil).each do |line_item|
+  		line_item.arm_id = nil
+  		line_item.save(validate: false)
+  	end
+  end
+end


### PR DESCRIPTION
One Time Fee line items should never have an arm_id, this causes bugs, and is bad data. Originally caused by sparc allowing this, which will be fixed in a PR for sparc.

#155263353

https://www.pivotaltracker.com/story/show/155263353