### PR TITLE
SJ - Fixing service_cost population bug, and fixing historical data

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -96,7 +96,6 @@ class Appointment < ApplicationRecord
               appointment_id: self.id,
               visit_id: visit.id,
               service_name: li.service.name,
-              service_cost: li.cost(li.protocol.sparc_funding_source),
               service_id: li.service.id,
               sparc_core_id: li.service.sparc_core_id,
               sparc_core_name: li.service.sparc_core_name

--- a/db/migrate/20180306213506_remove_costs_from_non_complete_procedures.rb
+++ b/db/migrate/20180306213506_remove_costs_from_non_complete_procedures.rb
@@ -1,0 +1,8 @@
+class RemoveCostsFromNonCompleteProcedures < ActiveRecord::Migration[5.0]
+  def change
+    Procedure.where.not(service_cost: nil, status: "complete").each do |procedure|
+      procedure.service_cost = nil
+      procedure.save(validate: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,23 +1,3 @@
-# Copyright © 2011-2018 MUSC Foundation for Research Development~
-# All rights reserved.~
-
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
-
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
-
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
-# disclaimer in the documentation and/or other materials provided with the distribution.~
-
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
-# derived from this software without specific prior written permission.~
-
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -30,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109153101) do
+ActiveRecord::Schema.define(version: 20180306213506) do
 
   create_table "appointment_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.string   "status"


### PR DESCRIPTION
So.... funny story. The original code in CWF that initializes an appointment's procedures created them WITH a price already filled in. This PR removes that VERY old line of code, and adds a migration to fix the historical data.

https://www.pivotaltracker.com/story/show/155760134

[#155760134]