### PR TITLE
Jl - Refactor of procedure reset

### DIFF
--- a/app/controllers/multiple_procedures_controller.rb
+++ b/app/controllers/multiple_procedures_controller.rb
@@ -54,10 +54,17 @@ class MultipleProceduresController < ApplicationController
 
     #Reset parent appointment
     @appointment.update_attributes(start_date: nil, completed_date: nil)
-    #Remove custom procedures from appointment
-    @appointment.procedures.where(visit_id: nil).each{|proc| proc.destroy_regardless_of_status}
-    #Reset all procedures under appointment
+ 
+    #Reset all procedures under appointment so they can be destroyed
     @appointment.procedures.each{|procedure| procedure.reset}
+    #Destroy all procedures
+    @appointment.procedures.each do |procedure|
+      procedure.destroy
+    end
+
+    #Reload appointment to grab any calendar changes, then initialize procedures
+    @appointment.reload
+    @appointment.initialize_procedures
 
     @refresh_dashboard = true
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1304306/stories/155377667

A completed appointment will not pick up changes on the calendar. In order bring a completed appointment up to date with the calendar on reset, all current procedures are destroyed and then recreated using the appointment's initialize_procedures method.