### PR TITLE
wth - (SPARCFulfillment) Homepage Pagination

### DIFF
--- a/app/views/protocols/_protocols.html.haml
+++ b/app/views/protocols/_protocols.html.haml
@@ -21,7 +21,7 @@
 #custom-toolbar
   = select_tag 'index_selectpicker', options_for_select((t(:sub_service_request)[:statuses].values.zip t(:sub_service_request)[:statuses].keys), 'All'), class: 'selectpicker'
 .bootstrap-table-dropdown-overflow
-  %table.protocols.custom_striped{id: "protocol-list", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: protocols_path(format: :json), "sort-name" => "sparc_id", "sort-order" => 'asc', cookie: "true", "cookie-id-table" => "protocols", striped: "true", toolbar: "#custom-toolbar", "show-export" => "true", "export-types" => ['excel']}}
+  %table.protocols.custom_striped{id: "protocol-list", data: {pagination: 'true', toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: protocols_path(format: :json), "sort-name" => "sparc_id", "sort-order" => 'asc', cookie: "true", "cookie-id-table" => "protocols", striped: "true", toolbar: "#custom-toolbar", "show-export" => "true", "export-types" => ['excel']}}
     %thead
       %tr
         %th{data: {class: 'srid', align: 'left', sortable: "true", field: 'srid'}}


### PR DESCRIPTION
Background: Currently, SPARCFulfillment homepage is a long list of all the requests the logged-in user have access to. So when the user has access to more than one organizations, or have a lot of requests, it is taking a long time to load the page. This is not efficient.

1). Please paginate fulfillment homepage (divide contents onto different pages), and make the general styling consistent with SPARCDashboard;
2). Please make sure the search function and other toolbox functions on top of the table are still working after the pagination, and the search box should still query through all the requests.

[#155658871]

Story - https://www.pivotaltracker.com/story/show/155658871