### PR TITLE
ml - form popup should persist with click

### DIFF
--- a/app/views/appointments/new.js.coffee
+++ b/app/views/appointments/new.js.coffee
@@ -19,5 +19,6 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 $("#modal_area").html("<%= escape_javascript(render(partial: 'form', locals: {appointment: @appointment, note: @note})) %>")
+$("#modal_place").modal(backdrop: 'static', keyboard: false)
 $("#modal_place").modal("show")
 $(".selectpicker").selectpicker()

--- a/app/views/line_items/edit.js.coffee
+++ b/app/views/line_items/edit.js.coffee
@@ -20,11 +20,13 @@
 
 <% if @otf %> # study level activities line item edit
 $("#modal_area").html("<%= escape_javascript(render(:partial =>'study_level_activities/study_level_activity_form', locals: {protocol: @protocol, line_item: @line_item, header_text: t(:line_item)[:edit]})) %>")
+$("#modal_place").modal(backdrop: 'static', keyboard: false)
 $("#date_started_field").datetimepicker
   format: 'MM/DD/YYYY'
   ignoreReadonly: true
 <% else %> # study schedule line item edit
 $("#modal_area").html("<%= escape_javascript(render(:partial =>'study_schedule/management/manage_services/change_service_form', locals: {line_item: @line_item})) %>")
+$("#modal_place").modal(backdrop: 'static', keyboard: false)
 <% end %>
 $(".selectpicker").selectpicker()
 $("#modal_place").modal 'show'

--- a/app/views/notes/index.js.coffee
+++ b/app/views/notes/index.js.coffee
@@ -19,4 +19,5 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 $("#modal_area").html("<%= escape_javascript(render(partial: 'index', locals: { notes: @notes, notable_type: @notable_type})) %>")
+$("#modal_place").modal(backdrop: 'static', keyboard: false)
 $("#modal_place").modal 'show'

--- a/app/views/participants/new.js.coffee
+++ b/app/views/participants/new.js.coffee
@@ -19,6 +19,7 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 $("#modal_area").html("<%= escape_javascript(render(:partial =>'participants/participant_form', locals: {protocol: @protocol, participant: @participant, header_text: 'Create New Participant'})) %>")
+$("#modal_place").modal(backdrop: 'static', keyboard: false)
 $("#modal_place").modal 'show'
 $("#dob_time_picker").datetimepicker
   format: 'MM/DD/YYYY'

--- a/app/views/procedures/edit.js.coffee
+++ b/app/views/procedures/edit.js.coffee
@@ -19,6 +19,7 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 $("#modal_area").html("<%= escape_javascript(render(partial: 'edit', locals: { procedure: @procedure, task: @task, clinical_providers: @clinical_providers})) %>")
+$("#modal_place").modal(backdrop: 'static', keyboard: false)
 $("#follow_up_procedure_datepicker").datetimepicker
   format: 'MM/DD/YYYY'
   ignoreReadonly: true

--- a/app/views/reports/new.js.coffee
+++ b/app/views/reports/new.js.coffee
@@ -19,6 +19,7 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 $("#modal_area").html("<%= escape_javascript(render(partial: @report_type, locals: { title: @title, report_type: @report_type })) %>")
+$("#modal_place").modal(backdrop: 'static', keyboard: false)
 $("#modal_place").modal('show')
 
 $('#start_date').datetimepicker

--- a/app/views/tasks/new.js.coffee
+++ b/app/views/tasks/new.js.coffee
@@ -19,6 +19,7 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 $("#modal_area").html("<%= escape_javascript(render(partial: 'form', locals: {task: @task, clinical_providers: @clinical_providers})) %>")
+$("#modal_place").modal(backdrop: 'static', keyboard: false)
 $("#modal_place").modal 'show'
 $("#follow_up_datepicker").datetimepicker
   format: 'MM/DD/YYYY'


### PR DESCRIPTION
All pop-up windows in Fulfillment allow the user to click off the window, which then eliminates previous selections. For example, when selecting the criteria for building a report and selecting "Organization(s) and/or Protocol(s)" from the drop-down list(s) it is not intuitive to know that you must "click" outside of the drop-down list once you have finished making your selections. When clicking off the report disappears - make the pop-up function persist when choosing from a dropdown.