### PR TITLE
Allow default grid columns to be configured [Pivotal #160151636]

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -36,7 +36,16 @@ class ProtocolsController < ApplicationController
     find_protocols_for_index
 
     respond_to do |format|
-      format.html { render }
+
+      format.html {
+        if cookies['protocols.bs.table.columns'].blank? && !ENV['DEFAULT_HOME_COLUMNS'].blank?
+          cookies['protocols.bs.table.columns'] = {
+            :value => ENV['DEFAULT_HOME_COLUMNS'].split(',').to_json,
+            :expires => 2.hours.from_now
+          }
+        end
+        render
+      }
       format.json { render }
       format.js
     end


### PR DESCRIPTION
If the user has made their own settings (which are stored in a cookie) they will be preserved