### PR TITLE
KG - Force WaitHelpers to wait until jQuery loaded on page

### DIFF
--- a/spec/support/features/wait_helpers.rb
+++ b/spec/support/features/wait_helpers.rb
@@ -26,8 +26,13 @@ module Features
 
     def wait_for_ajax
       Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until jquery_defined?
         loop until finished_all_ajax_requests? && finished_all_animations?
       end
+    end
+
+    def jquery_defined?
+      page.evaluate_script(%Q{typeof jQuery !== 'undefined'}) && page.evaluate_script(%Q{typeof $ !== 'undefined'})
     end
 
     def finished_all_ajax_requests?


### PR DESCRIPTION
Multiple pull requests in SPARC have had randomly failing specs with errors such as jQuery is undefined or $ is undefined. This is because the wait_for_javascript_to_finish helper is being called prior to when jQuery is loaded onto the page. Adding this check should prevent this issue from happening.