### PR TITLE
KG - Show Individual Line Items for "Remove Service"

### DIFF
--- a/app/assets/javascripts/study_schedule_management.js.coffee
+++ b/app/assets/javascripts/study_schedule_management.js.coffee
@@ -181,13 +181,4 @@ $ ->
       url: "/multiple_line_items/edit_line_items"
       data: 'protocol_id': $('#study_schedule_buttons').data('protocol-id')
 
-  $(document).on 'change', "#remove_service_id", ->
-    data =
-      'protocol_id' : $('#study_schedule_buttons').data('protocol-id')
-      'service_id'  : $(this).find('option:selected').val()
-    $.ajax
-      type: 'GET'
-      url: "/multiple_line_items/edit_line_items"
-      data: data
-
 ##          **END MANAGE LINE ITEMS**               ##

--- a/app/controllers/multiple_line_items_controller.rb
+++ b/app/controllers/multiple_line_items_controller.rb
@@ -60,10 +60,7 @@ class MultipleLineItemsController < ApplicationController
   def edit_line_items
     # called to render modal to mass remove line items
     protocol = Protocol.find(params[:protocol_id])
-    @line_items = protocol.line_items.includes(:arm, :service, appointments: :procedures).
-                    select{ |li| li.appointments.none?(&:has_completed_procedures?) }.
-                    group_by{ |li| li.arm.name }.
-                    map{ |arm, lis| [arm, lis.map{ |li| [li.name, li.id] }] }
+    @line_items = protocol.line_items.includes(:arm, :service, appointments: :procedures).select{ |li| li.appointments.none?(&:has_completed_procedures?) }
   end
 
   def destroy_line_items

--- a/app/controllers/multiple_line_items_controller.rb
+++ b/app/controllers/multiple_line_items_controller.rb
@@ -59,34 +59,16 @@ class MultipleLineItemsController < ApplicationController
 
   def edit_line_items
     # called to render modal to mass remove line items
-    @protocol = Protocol.find params[:protocol_id]
-    @all_services = @protocol.line_items.map(&:service).uniq
-    @service = params[:service_id].present? ? Service.find(params[:service_id]) : @all_services.first
-    @arms = @protocol.arms.select{ |arm| arm.line_items.detect{|li| li.service_id == @service.id} }
+    protocol = Protocol.find(params[:protocol_id])
+    @line_items = protocol.line_items.includes(:arm, :service, appointments: :procedures).
+                    select{ |li| li.appointments.none?(&:has_completed_procedures?) }.
+                    group_by{ |li| li.arm.name }.
+                    map{ |arm, lis| [arm, lis.map{ |li| [li.name, li.id] }] }
   end
 
   def destroy_line_items
     # handles submission of the remove line items form
-    @service = Service.find(params[:remove_service_id])
-    if params[:remove_service_arm_ids] # if they selected arms, otherwise add error
-      @arm_ids = [params[:remove_service_arm_ids]].flatten
-      line_items = @arm_ids.map{ |arm_id| LineItem.where("arm_id = #{arm_id} AND service_id = #{@service.id}").first } # get line_items to delete
-      @line_item_ids = line_items.map(&:id)
-      line_items.each do |li|
-        #TODO this keeps you from deleting if the appointment has ANY completed procedure
-        if li.visit_groups.map(&:appointments).flatten.map{|a| a.has_completed_procedures?}.include?(true) # don't delete if line_item has completed procedures
-          @service.errors.add(:service, "'#{li.name}' on Arm '#{li.arm.name}' has completed procedures and cannot be deleted")
-        end
-      end
-      unless @service.errors.present?
-        line_items.each{ |li| li.destroy }
-        flash.now[:success] = t(:services)[:deleted]
-      else
-        @errors = @service.errors
-      end
-    else
-      @service.errors.add(:arms, "to remove '#{@service.name}' from must be selected")
-      @errors = @service.errors
-    end
+    @line_items = LineItem.where(id: params[:line_item_ids]).destroy_all
+    flash.now[:success] = t(:services)[:deleted]
   end
 end

--- a/app/helpers/study_level_activities_helper.rb
+++ b/app/helpers/study_level_activities_helper.rb
@@ -58,7 +58,7 @@ module StudyLevelActivitiesHelper
   end
 
   def fulfillments_drop_button line_item
-    button = raw content_tag(:button, 'List', id: "list-#{line_item.id}", type: 'button', class: 'btn btn-success otf-fulfillment-list', title: 'List', type: "button", aria: {label: "List Fulfillments"}, data: {line_item_id: line_item.id})
+    button = raw content_tag(:button, 'List', id: "list-#{line_item.id}", class: 'btn btn-success otf-fulfillment-list', title: 'List', type: "button", aria: {label: "List Fulfillments"}, data: {line_item_id: line_item.id})
   end
 
   def is_protocol_type_study? (protocol)

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -33,6 +33,7 @@ class LineItem < ApplicationRecord
   has_many :admin_rates, primary_key: :sparc_id
 
   has_many :visit_groups, through: :arm
+  has_many :appointments, through: :visit_groups
 
   has_many :visits, -> { includes(:visit_group).order("visit_groups.position") }, dependent: :destroy
 

--- a/app/views/multiple_line_items/destroy_line_items.js.coffee
+++ b/app/views/multiple_line_items/destroy_line_items.js.coffee
@@ -18,19 +18,13 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-$("#modal_errors").html("<%= escape_javascript(render(partial: 'modal_errors', locals: {errors: @errors})) %>")
-<% unless @errors %>
-
-<% @line_item_ids.each do |li_id| %>
-$("#line_item_<%= li_id %>").remove()
-<% end %>
-<% @arm_ids.each do |arm_id| %>
-core_header = $("#arm_<%= arm_id %>_core_<%= @service.sparc_core_id %>")
-if core_header.next().attr('id') == "arm_<%= arm_id %>_end_of_core_<%= @service.sparc_core_id %>"
-  $("#arm_<%= arm_id %>_end_of_core_<%= @service.sparc_core_id %>").remove()
+<% @line_items.each do |li| %>
+$("#line_item_<%= li.id %>").remove()
+core_header = $("#arm_<%= li.arm_id %>_core_<%= li.service.sparc_core_id %>")
+if core_header.next().attr('id') == "arm_<%= li.arm_id %>_end_of_core_<%= li.service.sparc_core_id %>"
+  $("#arm_<%= li.arm_id %>_end_of_core_<%= li.service.sparc_core_id %>").remove()
   core_header.remove()
 <% end %>
-$("#modal_place").modal 'hide'
-$("#flashes_container").html("<%= escape_javascript(render('flash')) %>")
 
-<% end %>
+$("#modal_place").modal 'hide'
+$("#flashes_container").html("<%= j render 'flash' %>")

--- a/app/views/multiple_line_items/edit_line_items.js.coffee
+++ b/app/views/multiple_line_items/edit_line_items.js.coffee
@@ -18,6 +18,6 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-$("#modal_area").html("<%= escape_javascript(render(:partial =>'study_schedule/management/manage_services/remove_line_items_form', locals: { arms: @arms, all_services: @all_services, service: @service, protocol: @protocol })) %>");
+$("#modal_area").html("<%= j render 'study_schedule/management/manage_services/remove_line_items_form', line_items: @line_items %>");
 $("#modal_place").modal 'show'
 $(".selectpicker").selectpicker()

--- a/app/views/study_schedule/management/manage_services/_remove_line_items_form.html.haml
+++ b/app/views/study_schedule/management/manage_services/_remove_line_items_form.html.haml
@@ -36,7 +36,7 @@
             .form-group
               = label_tag :line_item_ids, t(:services)[:objects], class: "col-sm-4 control-label"
               .col-sm-7
-                = select_tag :line_item_ids, grouped_options_for_select(line_items), class: 'selectpicker', multiple: true
+                = select_tag :line_item_ids, grouped_options_for_select(line_items.group_by{ |li| li.arm.name }.map{ |arm, lis| [arm, lis.map{ |li| [li.name, li.id] }] }), class: 'form-control selectpicker', multiple: true
       .modal-footer
         .center-block
           %button.btn.btn-default{type: 'button', data: {dismiss: 'modal'}}

--- a/app/views/study_schedule/management/manage_services/_remove_line_items_form.html.haml
+++ b/app/views/study_schedule/management/manage_services/_remove_line_items_form.html.haml
@@ -34,11 +34,9 @@
         .row
           .col-md-12
             .form-group
-              = label_tag "remove_service_id", t(:services)[:object], class: "col-sm-4 control-label"
-              .col-sm-7= select_tag "remove_service_id", options_from_collection_for_select(all_services, 'id' , 'name', service.id), class: "form-control selectpicker"
-            .form-group
-              = label_tag "remove_service_arm_ids", t(:arm)[:objects]+t(:actions)[:required], class: "col-sm-4 control-label"
-              .col-sm-7= select_tag "remove_service_arm_ids[]", options_from_collection_for_select(arms, 'id' , 'name'), { class: "form-control selectpicker", multiple: "", title: "Please Select Arms", 'data-selected-text-format' => 'count>2'}
+              = label_tag :line_item_ids, t(:services)[:objects], class: "col-sm-4 control-label"
+              .col-sm-7
+                = select_tag :line_item_ids, grouped_options_for_select(line_items), class: 'selectpicker', multiple: true
       .modal-footer
         .center-block
           %button.btn.btn-default{type: 'button', data: {dismiss: 'modal'}}

--- a/spec/controllers/multiple_line_items_controller_spec.rb
+++ b/spec/controllers/multiple_line_items_controller_spec.rb
@@ -61,50 +61,28 @@ RSpec.describe MultipleLineItemsController, type: :controller do
   describe "GET #edit_line_items" do
 
     it "renders a template to remove a service from multiple arms" do
+      participant = create(:participant_with_appointments, protocol: @protocol, arm: @protocol.arms.first)
+                    create(:procedure_complete, service: @service, appointment: participant.appointments.first, arm: @protocol.arms.first)
+      complete_li = create(:line_item, service: @service, arm: @protocol.arms.first, protocol: @protocol)
+
       get :edit_line_items, params: {
-        protocol_id: @protocol.id,
-        service_id: @service.id
+        protocol_id: @protocol.id
       }, format: :js, xhr: true
 
-      expect(assigns(:protocol)).to eq(@protocol)
-      expect(assigns(:all_services)).to eq(@protocol.line_items.map(&:service).uniq)
-      expect(assigns(:service)).to eq(@service)
-      expect(assigns(:arms)).to eq((@protocol.arms.select{ |arm| arm.line_items.detect{|li| li.service_id == @service.id} }))
+      expect(assigns(:line_items)).to eq(@protocol.line_items.select{ |li| li.appointments.none?(&:has_completed_procedures?) })
     end
   end
 
   describe "PUT #destroy_line_items" do
     it "handles the submission of the remove line items form" do
-      create(:line_item, service: @service, arm: @protocol.arms.first, protocol: @protocol)
-      create(:line_item, service: @service, arm: @protocol.arms.second, protocol: @protocol)
+      li_1 = create(:line_item, service: @service, arm: @protocol.arms.first, protocol: @protocol)
+      li_2 = create(:line_item, service: @service, arm: @protocol.arms.second, protocol: @protocol)
 
       expect{
         post :destroy_line_items, params: {
-          remove_service_id: @service.id,
-          remove_service_arm_ids: ["#{@protocol.arms.first.id}", "#{@protocol.arms.second.id}"]
+          line_item_ids: [li_1.id, li_2.id]
         }, format: :js
       }.to change(LineItem, :count).by(-2)
-    end
-
-    it "requires arms to be selected" do
-      create(:line_item, service: @service, arm: @protocol.arms.first, protocol: @protocol)
-
-      expect{
-        post :destroy_line_items, params: { remove_service_id: @service.id }, format: :js
-      }.to_not change(LineItem, :count)
-    end
-
-    it "should not delete services with completed procedures" do
-      participant = create(:participant_with_appointments, protocol: @protocol, arm: @protocol.arms.first)
-                    create(:procedure_complete, service: @service, appointment: participant.appointments.first, arm: @protocol.arms.first)
-                    create(:line_item, service: @service, arm: @protocol.arms.first, protocol: @protocol)
-
-      expect{
-        post :destroy_line_items, params: {
-          remove_service_id: @service.id,
-          remove_service_arm_ids: ["#{@protocol.arms.first.id}"]
-        }, format: :js
-      }.to_not change(LineItem, :count)
     end
   end
 end

--- a/spec/features/study_schedule/management/identity_edits_services_spec.rb
+++ b/spec/features/study_schedule/management/identity_edits_services_spec.rb
@@ -85,10 +85,8 @@ feature 'Identity edits services for a particular protocol', js: true, enqueue: 
   end
 
   def when_i_select_a_service_and_arm
-    bootstrap_select "#remove_service_id", "#{@services.first.name}"
-    find("h4#line_item").click # click out of bootstrap multiple select
-
-    bootstrap_select "#remove_service_arm_ids_", "#{@arm.name}"
+    find('#line_item_ids', visible: false).sibling('.dropdown-toggle').click
+    first('.open .dropdown-menu a', text: @services.first.name).click
     find("h4#line_item").click # click out of bootstrap multiple select
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164802536

I originally simply changed the services to line items, but there was no way to distinguish the line items by arm. Instead, I grouped the services by arm so that there is now a single dropdown to select services (and you can select multiple at a time).

I also removed the validation from the `remove_line_items` route and instead hid line items that had completed procedures so that users can't select them in the first place.