### PR TITLE
JM - (SPARCFulfillment) SLA Export Bug

### DIFF
--- a/app/helpers/study_level_activities_helper.rb
+++ b/app/helpers/study_level_activities_helper.rb
@@ -40,7 +40,7 @@ module StudyLevelActivitiesHelper
 
   def notes notes
     bullet_point = notes.count > 1 ? "\u2022 " : ""
-    notes.map{ |note| bullet_point + note.comment + ", " + Identity.find(note.identity_id).full_name + ", " + note.created_at.strftime('%Y/%m/%d') }.join("<br>")
+    notes.map{ |note| bullet_point + note.comment+ ", " + note.created_at.strftime('%m/%d/%Y') + ", " + Identity.find(note.identity_id).full_name }.join("<br>")
   end
 
   def documents documents

--- a/app/helpers/study_level_activities_helper.rb
+++ b/app/helpers/study_level_activities_helper.rb
@@ -40,7 +40,7 @@ module StudyLevelActivitiesHelper
 
   def notes notes
     bullet_point = notes.count > 1 ? "\u2022 " : ""
-    notes.map{ |note| bullet_point + note.comment+ ", " + note.created_at.strftime('%m/%d/%Y') + ", " + Identity.find(note.identity_id).full_name }.join("<br>")
+    notes.map{ |note| bullet_point + note.created_at.strftime('%m/%d/%Y') + ", " + note.comment + ", " + Identity.find(note.identity_id).full_name }.join("<br>")
   end
 
   def documents documents


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/166085973

Ending with a date causes a parsing error.  Ensured that the string does not end with a date by moving the author token to the end.