### PR TITLE
Support env vars in sparc_db.yml

### DIFF
--- a/config/initializers/sparc_database.rb
+++ b/config/initializers/sparc_database.rb
@@ -18,4 +18,6 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-SPARC_DB = YAML.load_file(File.join(Rails.root, "config", "sparc_db.yml"))[Rails.env.to_s]
+path = File.join(Rails.root, "config", "sparc_db.yml")
+yaml = Pathname.new(path) if path
+SPARC_DB = YAML.load(ERB.new(yaml.read).result)[Rails.env.to_s]


### PR DESCRIPTION
Run `sparc_db.yml` through ERB to support environment variables. For example,

```
development:
  <<: *default
  host: <%= ENV['SPARC_DB_HOST'] %>
  database: <%= ENV['SPARC_DB_NAME'] %>
  username: <%= ENV['SPARC_DB_USER'] %>
  password: <%= ENV['SPARC_DB_PASS'] %>
```