### PR TITLE
Jl - visit report participant name bug

### DIFF
--- a/lib/reports/visit_report.rb
+++ b/lib/reports/visit_report.rb
@@ -78,9 +78,9 @@ class VisitReport < Report
 
       sorted_result_set = sort_result_set(result_set)
 
-      sorted_result_set[0].each do |appointment|
+      sorted_result_set.each do |appointment|
         if HAS_RMID
-          csv << [appointment[0], sorted_result_set[1], appointment[1], appointment[2], appointment[3], is_custom_visit(appointment),
+          csv << [appointment[0], appointment[12], appointment[1], appointment[2], appointment[3], is_custom_visit(appointment),
                   get_date(appointment, true), get_date(appointment, false), get_duration(appointment),
                   get_content(appointment), get_statuses(appointment[6])]
         else
@@ -93,20 +93,21 @@ class VisitReport < Report
   end
 
   def sort_result_set(result_set)
-    protocol = Protocol.find(appointment[0])
     used_appointments = []
     sorted_set = []
     result_set.each do |appointment|
+      protocol = Protocol.find(appointment[0])
       comparison_array = [appointment[0], appointment[1], appointment[2], appointment[3], get_duration(appointment), appointment[6]]
       unless used_appointments.include?(comparison_array)
         used_appointments << comparison_array
         srid = protocol.srid
         appointment[0] = srid
+        appointment << protocol.research_master_id
         sorted_set << appointment
       end
     end
     
-    [sorted_set.sort{ |x, y| x <=> y || 1 }, protocol.rmid]
+    sorted_set.sort{ |x, y| x <=> y || 1 }
   end
 
   def is_custom_visit(appointment)

--- a/lib/reports/visit_report.rb
+++ b/lib/reports/visit_report.rb
@@ -75,19 +75,30 @@ class VisitReport < Report
                       Procedure.arel_table[:status], Procedure.arel_table[:sparc_core_name], Appointment.arel_table[:contents])
 
       get_protocol_rmid(result_set) if ENV.fetch('RMID_URL'){nil}
-      get_protocol_srids(result_set)
+      sorted_result_set = sort_result_set(result_set)
 
-      result_set.group_by { |protocol, last_name, first_name, visit_name| [protocol, last_name, first_name, visit_name] }.
-        map      { |grouping, appointments| get_appointment_info(grouping) <<
-                                            is_custom_visit(appointments) <<
-                                            get_date(appointments[0][4]) <<
-                                            get_date(appointments[0][5]) <<
-                                            get_duration(appointments[0]) <<
-                                            get_content(appointments[0]) <<
-                                            get_statuses(appointments[0][8])}.
-        sort     { |x, y| x <=> y || 1 }.
-        each     { |line|    csv << line }
+      sorted_result_set.each do |appointment|
+        csv << [appointment[0], appointment[1], appointment[2], appointment[3], is_custom_visit(appointment),
+                get_date(appointment, true), get_date(appointment, false), get_duration(appointment), appointment[6]]
+         #        get_content(appointment), get_statuses(appointment[6])]
+      end
     end
+  end
+
+  def sort_result_set(result_set)
+    used_appointments = []
+    sorted_set = []
+    result_set.each do |appointment|
+      comparison_array = [appointment[0], appointment[1], appointment[2], appointment[3], get_duration(appointment), appointment[6]]
+      unless used_appointments.include?(comparison_array)
+        used_appointments << comparison_array
+        srid = Protocol.find(appointment[0]).srid
+        appointment[0] = srid
+        sorted_set << appointment
+      end
+    end
+    
+    sorted_set.sort{ |x, y| x <=> y || 1 }
   end
 
   def get_appointment_info(grouping)
@@ -98,25 +109,20 @@ class VisitReport < Report
     end
   end
 
-  def is_custom_visit(appointments)
-    appointments.detect{ |appointment| appointment[6].nil? } ? "Yes" : "No"
+  def is_custom_visit(appointment)
+    appointment[6].nil? ? "Yes" : "No"
   end
 
   def get_duration(appointment)
     appointment[5].nil? ? "N/A" : ((appointment[5] - appointment[4])/60).round
   end
 
-  def get_date(appointment)
-    appointment.nil? ? "N/A" : format_date(appointment)
-  end
-
-  def get_protocol_srids(result_set)
-    protocol_ids = result_set.map(&:first).uniq
-    # SRID's indexed by protocol id
-    @srid = Hash[ Protocol.includes(:sub_service_request).
-                  select(:id, :sparc_id, :sub_service_request_id). # cols necessary for SRID
-                  where(id: protocol_ids).
-                  map { |protocol| [protocol.id, protocol.srid] }]
+  def get_date(appointment, start)
+    if start == true
+      return appointment[4].nil? ? "N/A" : format_date(appointment[4])
+    else
+      return appointment[5].nil? ? "N/A" : format_date(appointment[5])
+    end
   end
 
   def get_protocol_rmid(result_set)
@@ -128,8 +134,8 @@ class VisitReport < Report
                   map { |protocol| [protocol.id, protocol.research_master_id] }]
   end
 
-  def get_content(appointments)
-    appointments[11].nil? ? nil : appointments[11]
+  def get_content(appointment)
+    appointment[11].nil? ? nil : appointment[11]
   end
 
   def get_statuses(appointment_id)


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1304306/stories/169631270

Using 'group_by' was eliminating valid participants that had the same first name, last name, protocol, and appointment. Although this is a rare case these participants do exist in the data. 