### PR TITLE
SJ - Fulfillments Cost Fix

### DIFF
--- a/app/controllers/fulfillments_controller.rb
+++ b/app/controllers/fulfillments_controller.rb
@@ -45,7 +45,7 @@ class FulfillmentsController < ApplicationController
     service = @line_item.service
     funding_source = @line_item.protocol.sparc_funding_source
     fulfilled_at = fulfillment_params[:fulfilled_at]
-    @fulfillment = Fulfillment.new(fulfillment_params.merge!({ creator: current_identity, service: service, service_name: service.name, service_cost: @line_item.cost(funding_source, fulfilled_at), funding_source: funding_source }))
+    @fulfillment = Fulfillment.new(fulfillment_params.merge!({ creator: current_identity, service: service, service_name: service.name, service_cost: @line_item.cost(funding_source, Time.strptime(fulfilled_at, "%m/%d/%Y")), funding_source: funding_source }))
     if @fulfillment.valid?
       perform_subsidy_check
       @fulfillment.save

--- a/app/controllers/fulfillments_controller.rb
+++ b/app/controllers/fulfillments_controller.rb
@@ -44,7 +44,8 @@ class FulfillmentsController < ApplicationController
     @line_item = LineItem.find(fulfillment_params[:line_item_id])
     service = @line_item.service
     funding_source = @line_item.protocol.sparc_funding_source
-    @fulfillment = Fulfillment.new(fulfillment_params.merge!({ creator: current_identity, service: service, service_name: service.name, service_cost: @line_item.cost(funding_source), funding_source: funding_source }))
+    fulfilled_at = fulfillment_params[:fulfilled_at]
+    @fulfillment = Fulfillment.new(fulfillment_params.merge!({ creator: current_identity, service: service, service_name: service.name, service_cost: @line_item.cost(funding_source, fulfilled_at), funding_source: funding_source }))
     if @fulfillment.valid?
       perform_subsidy_check
       @fulfillment.save

--- a/lib/tasks/import_klok_data.rake
+++ b/lib/tasks/import_klok_data.rake
@@ -93,7 +93,7 @@ task import_klok: :environment do
         fulfillment = Fulfillment.where(klok_entry_id: entry.entry_id, line_item: line_item).first_or_initialize
 
         fulfillment.assign_attributes(fulfilled_at: entry.date.strftime('%m/%d/%Y').to_s, quantity: entry.decimal_duration, creator_id: local_identity.id, performer_id: local_identity.id,
-                                      service: service, service_name: service.name, service_cost: line_item.cost(local_protocol.sparc_funding_source, entry.created_at))
+                                      service: service, service_name: service.name, service_cost: line_item.cost(local_protocol.sparc_funding_source, entry.start_time_stamp))
 
         ### build out components
         fulfillment.components.build(component: entry.klok_project.name) if entry.klok_project.name && fulfillment.components.select{|x| x.component == entry.klok_project.name}.empty?


### PR DESCRIPTION
Fixing huge bug with fulfillment cost calculation

Fulfillments, when created, were NOT using the "fulfilled_at" date being passed in, they were using Time.now, because we weren't passing the date into the cost method -.-