### PR TITLE
SJ - API/Travis Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - cd ..
   - git clone https://github.com/sparc-request/sparc-request.git
   - cd sparc-request
-  - git checkout v3.7.0
+  - git checkout v3.8.0
   - rvm use $(< .ruby-version) --install --binary --fuzzy
   - export BUNDLE_GEMFILE=$PWD/Gemfile
   - gem install bundler


### PR DESCRIPTION
Changing SPARC version to v3.8.0 in Travis config.

This will help highlight the changes to the API in SPARC, so we can fix the issues here as well.

@kayla-glick The specs running here SHOULD highlight the broken sections of CWF.