### PR TITLE
SAW - BS4 Participant Calendar Changes

### DIFF
--- a/app/assets/javascripts/appointments.js.coffee
+++ b/app/assets/javascripts/appointments.js.coffee
@@ -74,16 +74,6 @@ $ ->
       url: "/procedures/#{procedure_id}.js"
       data: data
 
-  $(document).on 'dp.hide', ".followup_procedure_datepicker", ->
-    task_id = $(this).data("taskId")
-    due_at = $(this).val()
-    data = task:
-            due_at: due_at
-    $.ajax
-      type: 'PUT'
-      url: "/tasks/#{task_id}.js"
-      data: data
-
   $(document).on 'change', '.billing_type.bootstrap-select', ->
     procedure    = $(this).parents('tr.procedure')
     procedure_id = $(procedure).data('id')
@@ -209,3 +199,14 @@ $ ->
 
       find_ids group_id for group_id in group_ids
       return procedure_ids
+
+(exports ? this).updateFollowupDate = (this_elem, old_date) ->
+  input = this_elem.find('.datetimepicker-input')
+  if input.val() == ""
+    input.removeClass('datetimepicker-input')
+    this_elem.datetimepicker('date', old_date)
+    input.addClass('datetimepicker-input')
+  else if !moment(input.val()).isSame(moment(old_date))
+    form = this_elem.parent()[0]
+    console.log("Form about to be submitted")
+    Rails.fire(form, 'submit')

--- a/app/assets/javascripts/appointments.js.coffee
+++ b/app/assets/javascripts/appointments.js.coffee
@@ -208,5 +208,4 @@ $ ->
     input.addClass('datetimepicker-input')
   else if !moment(input.val()).isSame(moment(old_date))
     form = this_elem.parent()[0]
-    console.log("Form about to be submitted")
     Rails.fire(form, 'submit')

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -51,8 +51,18 @@ module AppointmentHelper
   end
 
   def complete_appointment_buttons(appointment)
-    content_tag :div, class: 'tooltip-wrapper', title: appointment.can_finish? ? '' : t('appointments.tooltips.complete_visit.disabled'), data: { toggle: 'tooltip' } do
-      content_tag :button, class: ['btn btn-success complete-appointment', appointment.can_finish? ? '' : 'disabled'], data: { url: appointment_path(appointment), confirm_swal: true } do
+    title = ''
+    disabled_class = ''
+    if appointment.completed?
+      title = t('appointments.tooltips.complete_visit.completed')
+      disabled_class = 'disabled'
+    elsif !appointment.can_finish?
+      title = t('appointments.tooltips.complete_visit.disabled')
+      disabled_class = 'disabled'
+    end
+
+    content_tag :div, class: 'tooltip-wrapper', title: title, data: { toggle: 'tooltip' } do
+      content_tag :button, class: "btn btn-success complete-appointment #{disabled_class}", data: { url: appointment_path(appointment), confirm_swal: true } do
         icon('fas', 'check mr-1') + t('appointments.complete_visit')
       end
     end

--- a/app/helpers/procedures_helper.rb
+++ b/app/helpers/procedures_helper.rb
@@ -141,20 +141,20 @@ module ProceduresHelper
   end
 
   def delete_procedure_button(procedure)
-    disabled = !procedure.appointment.started? || procedure.invoiced? || procedure.credited?
+    disabled = !procedure.appointment.started? || procedure.complete? || procedure.incomplete?
     tooltip =
       if !procedure.appointment.started?
         t('procedures.tooltips.unstarted_appointment')
-      elsif procedure.invoiced?
-        t('procedures.tooltips.invoiced.disabled')
-      elsif procedure.credited?
-        t('procedures.tooltips.credited.disabled')
+      elsif procedure.complete?
+        t('procedures.tooltips.completed.disabled')
+      elsif procedure.incomplete?
+        t('procedures.tooltips.incompleted.disabled')
       else
         t('procedures.tooltips.delete')
       end
 
     content_tag :div, class: 'tooltip-wrapper', title: tooltip, data: { toggle: 'tooltip' } do
-      link_to icon('fas', 'trash'), appointment_procedure_path(procedure, appointment_id: procedure.appointment_id), remote: true, method: :delete, class: ['btn btn-danger', disabled ? 'disabled' : ''], data: { confirm_swal: 'true' }
+      link_to icon('fas', 'trash'), appointment_procedure_path(procedure, appointment_id: procedure.appointment_id), remote: true, method: :delete, class: ['btn btn-danger delete-button', disabled ? 'disabled' : ''], data: { confirm_swal: 'true', procedure: procedure.id }
     end
   end
 

--- a/app/helpers/protocols_participant_helper.rb
+++ b/app/helpers/protocols_participant_helper.rb
@@ -76,7 +76,7 @@ module ProtocolsParticipantHelper
   end
 
   def protocols_participant_details_button(protocols_participant)
-    link_to protocol_participant_path(protocols_participant, protocol_id: protocols_participant.protocol_id), remote: true, class: 'btn btn-sq btn-info mr-1 participant-details', title: t('actions.details'), data: { toggle: 'tooltip' } do
+    link_to participant_details_path(protocols_participant), remote: true, class: 'btn btn-sq btn-info mr-1 participant-details is-this-update', title: t('actions.details'), data: { toggle: 'tooltip' } do
       icon('fas', 'eye')
     end
   end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -36,7 +36,7 @@ class Procedure < ApplicationRecord
 
   belongs_to :appointment
   belongs_to :visit
-  belongs_to :service
+  belongs_to :service, required: true
   belongs_to :performer, class_name: "Identity"
   belongs_to :core, class_name: "Organization", foreign_key: :sparc_core_id
 

--- a/app/views/appointments/_calendar.html.haml
+++ b/app/views/appointments/_calendar.html.haml
@@ -48,9 +48,9 @@
         Add Services
     .card-body
       .row
-        .col-8
+        .form-group.mb-0.col-8
           = f.select :service_id, options_from_collection_for_select(appointment.protocol.organization.inclusive_child_services(:per_participant), 'id', 'name'), { include_blank: true }, class: 'form-control selectpicker'
-        .col-2
+        .form-group.mb-0.col-2
           = f.text_field :qty, value: 1, class: 'form-control'
         .col-2
           %button.btn.btn-success.w-100#addService

--- a/app/views/procedures/_followup.html.haml
+++ b/app/views/procedures/_followup.html.haml
@@ -32,8 +32,8 @@
   .tooltip-wrapper{ title: tooltip, data: { toggle: 'tooltip' } }
     - if procedure.task.present?
       = form_for procedure.task, url: task_path(procedure.task), remote: true, method: :put do |f|
-        .input-group.datetimepicker.date{ id: "followupDatePicker#{procedure.id}", data: { target_input: 'nearest' } }
-          = f.text_field :due_at, class: 'datetimepicker-input form-control', value: format_date(procedure.task.due_at), onchange: "Rails.fire(this.form, 'submit')", disabled: disabled, data: { target: "#followupDatePicker#{procedure.id}" }
+        .input-group.datetimepicker.date.followup-datepicker{ id: "followupDatePicker#{procedure.id}", onchange: "updateFollowupDate($(this), '#{procedure.task.due_at.to_formatted_s(:iso8601)}')", data: { target_input: 'nearest' } }
+          = f.text_field :due_at, class: 'datetimepicker-input form-control', id: "followupDatePickerInput#{procedure.id}", value: format_date(procedure.task.due_at), disabled: disabled, data: { target: "#followupDatePicker#{procedure.id}" }
     - else
       = link_to edit_appointment_procedure_path(procedure, appointment_id: procedure.appointment_id), remote: true, class: ['btn btn-warning', disabled ? 'disabled' : ''] do
         = icon('fas', 'calendar-alt')

--- a/app/views/procedures/create.js.coffee
+++ b/app/views/procedures/create.js.coffee
@@ -1,0 +1,35 @@
+# Copyright © 2011-2020 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+<% if @errors %>
+$('.services form .form-group').removeClass('is-invalid').addClass('is-valid')
+$('.form-error').remove()
+
+<% @errors.messages.each do |attr, messages| %>
+<% messages.each do |message| %>
+<% if attr.to_s == "service"%>
+$("[name='service_id']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% elsif attr.to_s == "base" %>
+$("[name='qty']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% end%>
+<% end %>
+<% end %>
+
+<% end %>

--- a/app/views/procedures/update.js.coffee
+++ b/app/views/procedures/update.js.coffee
@@ -79,6 +79,8 @@ statuses[statuses.length] =  "<%= status %>"
 
 $(".appointment-action-buttons").html("<%= j render '/appointments/appointment_action_buttons', appointment: @appointment %>")
 
+$('.delete-button[data-procedure="<%= @procedure.id %>"]').replaceWith("<%= j delete_procedure_button(@procedure) %>")
+
 $("#group-<%= @procedure.group_id %> button").trigger('click')
 
 updateNotesBadge("procedure<%= @procedure.id %>", "<%= @procedure.notes.count %>")

--- a/app/views/procedures/update.js.coffee
+++ b/app/views/procedures/update.js.coffee
@@ -79,7 +79,7 @@ statuses[statuses.length] =  "<%= status %>"
 
 $(".appointment-action-buttons").html("<%= j render '/appointments/appointment_action_buttons', appointment: @appointment %>")
 
-$('.delete-button[data-procedure="<%= @procedure.id %>"]').replaceWith("<%= j delete_procedure_button(@procedure) %>")
+$('.delete-button[data-procedure="<%= @procedure.id %>"]').parent('.tooltip-wrapper').replaceWith("<%= j delete_procedure_button(@procedure) %>")
 
 $("#group-<%= @procedure.group_id %> button").trigger('click')
 

--- a/app/views/tasks/create.js.coffee
+++ b/app/views/tasks/create.js.coffee
@@ -43,12 +43,6 @@ updateNotesBadge("procedure<%= @procedure.id %>", "<%= @procedure.notes.length %
 <% if @appointment.present? %>
 $('.appointments').html("<%= j render 'appointments/calendar', appointment: @appointment, appointment_style: @appointment_style %>")
 
-if !$('.start_date_input').hasClass('hidden')
-  start_date_init("<%= format_datetime(@appointment.start_date) %>")
-
-if !$('.completed_date_input').hasClass('hidden')
-  completed_date_init("<%= format_datetime(@appointment.completed_date) %>")
-
 $('#appointment_content_indications').selectpicker()
 $('#appointment_content_indications').selectpicker('val', "<%= @appointment.contents %>")
 $(".selectpicker").selectpicker()

--- a/app/views/tasks/create.js.coffee
+++ b/app/views/tasks/create.js.coffee
@@ -58,19 +58,6 @@ statuses = []
 statuses[statuses.length] =  "<%= status %>"
 <% end %>
 
-$(".followup_procedure_datepicker").datetimepicker
-  format: 'MM/DD/YYYY'
-  ignoreReadonly: true
-  allowInputToggle: false
-
-$(".completed_date_field").datetimepicker
-  format: 'MM/DD/YYYY'
-  allowInputToggle: false
-
 $('.row.appointment [data-toggle="tooltip"]').tooltip()
 <% end %>
-
-$(".followup_procedure_datepicker").datetimepicker
-  format: 'MM/DD/YYYY'
-  allowInputToggle: false
   

--- a/app/views/tasks/create.js.coffee
+++ b/app/views/tasks/create.js.coffee
@@ -43,10 +43,6 @@ updateNotesBadge("procedure<%= @procedure.id %>", "<%= @procedure.notes.length %
 <% if @appointment.present? %>
 $('.appointments').html("<%= j render 'appointments/calendar', appointment: @appointment, appointment_style: @appointment_style %>")
 
-$('#appointment_content_indications').selectpicker()
-$('#appointment_content_indications').selectpicker('val', "<%= @appointment.contents %>")
-$(".selectpicker").selectpicker()
-
 statuses = []
 <% @statuses.each do |status| %>
 statuses[statuses.length] =  "<%= status %>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -514,8 +514,12 @@ en:
     tooltips:
       unstarted_appointment: "Click 'Start Visit' and enter a start date to continue."
       complete: "Complete"
+      completed:
+        disabled: "This procedure has been completed and cannot be deleted"
       unstarted: "Unstarted"
       incomplete: "Incomplete"
+      incompleted:
+        disabled: "This procedure is incomplete and cannot be deleted"
       followup:
         schedule: "Schedule a follow-up"
       invoiced:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,7 @@ en:
         grouped: "Switch to Grouped View"
       complete_visit:
         disabled: "Assign a status or follow-up date for each procedure in order to complete this visit."
+        completed: "This visit has already been completed"
       reset_visit:
         disabled_invoiced: "A procedure within this visit has been invoiced and cannot be altered."
         disabled_credited: "A procedure within this visit has been credited and cannot be altered."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,12 @@ en:
           attributes:
             position:
               blank: "You must select a Position"
+        procedure:
+          attributes:
+            base:
+              qty: "Must be greater than zero"
+            service:
+              required: "You ust select a Service"
         visit_group:
           attributes:
             position:


### PR DESCRIPTION
[#176057388](https://www.pivotaltracker.com/story/show/176057388)

Made changes to the Participant Calendar to address feedback to the Bootstrap 4 upgrades listed on Pivotal. This does _not_ the Participant Tracker, that will be in another PR so this one isn't too big.

- Fixed the participants view details button, that now displays without any silent errors
- In the Add Service section, added small error messages when the service quantity is 0 or when no service is selected. The styling of these error messages looks consistent with other form errors.
- The Complete Visit button at the top of the page is disabled with a corresponding tooltip if the visit is already completed.
- Complete and incomplete procedures couldn't be deleted (`destroy` on the procedures model was defined to not allow complete and incomplete procedures to be destroyed) so it was throwing a generic ActiveModel error. The delete procedure buttons on the calendar were updated to be disabled with corresponding tooltip to match.
- Procedure followup date had a few issues. There were silent 500 errors that didn't seem to hinder functionality, but were errors regardless. Those were from no longer needed javascript in `tasks/update.js.coffee`, so those lines were removed. There was also an issue with TempusDominus where it would error if the date field was emptied, and the field would stop responding to our JS handlers for submitting a new followup date after it errored. This actually seems to be an issue across all of our datetimepickers in SPARCFulfillment and SPARCRequest, but since this is a live saving field, this issue actually mattered. So now instead of a more typical JS handler using `change.datetimepicker`, I used the `onchange` html attribute to call a different method that seems to avoid the error in the first place by removing the datetimepicker-input class.