### PR TITLE
SAW - BS4 Participant Tracker Changes

### DIFF
--- a/app/helpers/protocols_participant_helper.rb
+++ b/app/helpers/protocols_participant_helper.rb
@@ -38,7 +38,7 @@ module ProtocolsParticipantHelper
 
   def protocols_participant_arm_dropdown(protocols_participant)
     form_for protocols_participant, url: protocol_participant_path(protocols_participant, protocol_id: protocols_participant.protocol_id), method: :put, remote: true do |f|
-      f.select :arm_id, options_from_collection_for_select(protocols_participant.protocol.arms, :id, :name, protocols_participant.id), { include_blank: protocols_participant.arm.nil? }, class: 'selectpicker', onchange: "Rails.fire(this.form, 'submit')"
+      f.select :arm_id, options_from_collection_for_select(protocols_participant.protocol.arms, :id, :name, protocols_participant.arm.id), { include_blank: protocols_participant.arm.nil? }, class: 'selectpicker', onchange: "Rails.fire(this.form, 'submit')"
     end
   end
 

--- a/app/helpers/protocols_participant_helper.rb
+++ b/app/helpers/protocols_participant_helper.rb
@@ -48,8 +48,8 @@ module ProtocolsParticipantHelper
     disabled              = !protocols_participant.can_be_destroyed?
     url                   = associated ? destroy_protocol_participant_path(protocols_participant, protocol_id: protocol.id) : protocol_participants_path(protocol_id: protocol.id, participant_id: participant.id)
     ajax_method           = associated ? :delete : :post
-    klass                 = ['btn btn-sm btn-sq', associated ? 'btn-danger remove-participant' : 'btn-success add-participant']
-    icon_klass            = associated ? 'times' : 'check'
+    klass                 = ['btn btn-sm btn-sq', associated ? 'btn-danger remove-participant' : 'btn-primary add-participant']
+    icon_klass            = associated ? 'times' : 'plus'
     tooltip               = disabled ? 'cant_delete' : (associated ? 'remove' : 'add')
 
     link_to url, method: ajax_method, remote: true, class: klass, title: t("protocols_participants.tooltips.#{tooltip}"), data: { toggle: 'tooltip' } do

--- a/app/helpers/protocols_participant_helper.rb
+++ b/app/helpers/protocols_participant_helper.rb
@@ -46,7 +46,7 @@ module ProtocolsParticipantHelper
     protocols_participant = protocol.protocols_participants.find_by(participant_id: participant.id) || protocol.protocols_participants.new(participant_id: participant.id)
     associated            = !protocols_participant.new_record?
     disabled              = !protocols_participant.can_be_destroyed?
-    url                   = associated ? protocol_participant_path(protocols_participant, protocol_id: protocol.id) : protocol_participants_path(protocol_id: protocol.id, participant_id: participant.id)
+    url                   = associated ? destroy_protocol_participant_path(protocols_participant, protocol_id: protocol.id) : protocol_participants_path(protocol_id: protocol.id, participant_id: participant.id)
     ajax_method           = associated ? :delete : :post
     klass                 = ['btn btn-sm btn-sq', associated ? 'btn-danger remove-participant' : 'btn-success add-participant']
     icon_klass            = associated ? 'times' : 'check'
@@ -69,7 +69,7 @@ module ProtocolsParticipantHelper
   def protocols_participant_delete_button(protocols_participant)
     disabled = !protocols_participant.can_be_destroyed?
     content_tag(:div, class: 'tooltip-wrapper', title: disabled ? t('protocols_participants.tooltips.cant_delete') : t('actions.delete'), data: { toggle: 'tooltip', boundary: 'window' }) do
-      link_to protocol_participant_path(protocols_participant, protocol_id: protocols_participant.protocol_id), method: :delete, remote: true, class: ['btn btn-sq btn-danger remove-participant', disabled ? 'disabled' : ''], data: { confirm_swal: 'true' } do
+      link_to destroy_protocol_participant_path(protocols_participant, protocol_id: protocols_participant.protocol_id), method: :delete, remote: true, class: ['btn btn-sq btn-danger remove-participant', disabled ? 'disabled' : ''], data: { confirm_swal: 'true' } do
         icon('fas', 'trash')
       end
     end

--- a/app/models/protocols_participant.rb
+++ b/app/models/protocols_participant.rb
@@ -104,7 +104,7 @@ class ProtocolsParticipant < ApplicationRecord
   private
 
   def has_new_visit_groups?
-    self.new_visit_groups.any?
+    new_visit_groups.any?
   end
 
   def new_visit_groups

--- a/app/models/protocols_participant.rb
+++ b/app/models/protocols_participant.rb
@@ -36,7 +36,7 @@ class ProtocolsParticipant < ApplicationRecord
   delegate :first_name, :last_name, :first_middle, :full_name, :mrn, to: :participant
 
   before_save :note_changes,                      if: Proc.new{ |p| p.arm_id_changed? || p.status_changed? }
-  after_save :update_appointments_on_arm_change,  if: Proc.new{ |p| p.arm_id_changed? }
+  after_save :update_appointments_on_arm_change,  if: Proc.new{ |p| p.saved_change_to_arm_id? }
 
   after_save :update_faye
   after_destroy :update_faye

--- a/app/views/protocols_participants/_participant_info.html.haml
+++ b/app/views/protocols_participants/_participant_info.html.haml
@@ -29,7 +29,7 @@
           = Participant.human_attribute_name(:mrn)
         %th.external-id.editable{ data: { field: 'external_id_read', align: 'center' } }
           = ProtocolsParticipant.human_attribute_name(:external_id)
-        %th.arm{ data: { field: 'arm_reaed', align: 'center' } }
+        %th.arm{ data: { field: 'arm_read', align: 'center' } }
           = ProtocolsParticipant.human_attribute_name(:arm)
         %th.status{ data: { field: 'status_read', align: 'center' } }
           = ProtocolsParticipant.human_attribute_name(:status)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
       member do
         get 'calendar', to: 'protocols_participants#show', as: 'calendar'
         put 'update', to: 'protocols_participants#update'
+        delete :destroy, as: 'destroy'
       end
 
       put 'change_recruitment_source(/:id)', to: 'participants#update_recruitment_source'


### PR DESCRIPTION
[#176057388](https://www.pivotaltracker.com/story/show/176057388)

Addressed other issues with the Participant Tracker (see #890):

- Fixed Protocols Participant delete buttons silent error
- Changed the associate button from a green check button to a primary plus button for clarity
- Appointments are now properly built for a participant when the arm is updated. This includes the case when a participant is added to a protocol with only one arm. The participant is added to the only arm on the protocol on association and appointments are built. This was broken because of [changes to ActiveRecord::Dirty in Rails 5.2](https://www.fastruby.io/blog/rails/upgrades/active-record-5-1-api-changes.html)
- Fixed typo preventing arm name from displaying on the Participant Calendar header
- Removed `self.` from a call to a private method within the private scope in the Protocols Participant model that caused some issues
- Fixed the selectpicker to update arm on a participant. It functioned, but did not display the the right arm on the participant.