### PR TITLE
SAW - BS4: Clinical Services Calendar Bug

### DIFF
--- a/app/helpers/study_schedule_helper.rb
+++ b/app/helpers/study_schedule_helper.rb
@@ -62,12 +62,20 @@ module StudyScheduleHelper
   end
 
   def on_current_page? current_page, position
+    destination_page(position) == current_page.to_i
+  end
+
+  def before_current_page? current_page, position
+    destination_page(position) < current_page.to_i
+  end
+
+  def destination_page position
     destination_page = position / Visit.per_page
     if position % Visit.per_page != 0
       destination_page += 1
     end
 
-    destination_page == current_page.to_i
+    return destination_page
   end
 
   def create_line_items_options page_hash

--- a/app/views/visit_groups/create.js.coffee
+++ b/app/views/visit_groups/create.js.coffee
@@ -36,7 +36,7 @@ tab = $('#current_tab').val()
 $("#select_for_arm_#{arm_id}").replaceWith("<%= j render '/study_schedule/visit_group_page_select', arm: @arm, page: @current_page.to_i %>")
 $(".selectpicker").selectpicker()
 
-<% if on_current_page?(@current_page, @visit_group.position) %>
+<% if on_current_page?(@current_page, @visit_group.position) || before_current_page?(@current_page, @visit_group.position) %>
 # Overwrite the visit_groups
 $(".visit_groups_for_#{arm_id}").html("<%= j render '/study_schedule/visit_groups', arm: @arm, visit_groups: @visit_groups, tab: @schedule_tab %>")
 # Overwrite the check columns

--- a/app/views/visit_groups/destroy.js.coffee
+++ b/app/views/visit_groups/destroy.js.coffee
@@ -36,7 +36,7 @@ tab = $('#current_tab').val()
 $("#select_for_arm_#{arm_id}").replaceWith("<%= j render '/study_schedule/visit_group_page_select', arm: @arm, page: @current_page.to_i %>")
 $(".selectpicker").selectpicker()
 
-<% if on_current_page?(@current_page, @visit_group.position) %>
+<% if on_current_page?(@current_page, @visit_group.position) || before_current_page?(@current_page, @visit_group.position) %>
 # Overwrite the visit_groups
 $(".visit_groups_for_#{arm_id}").html("<%= j render '/study_schedule/visit_groups', arm: @arm, visit_groups: @visit_groups, tab: @schedule_tab %>")
 # Overwrite the check columns

--- a/app/views/visit_groups/update.js.coffee
+++ b/app/views/visit_groups/update.js.coffee
@@ -36,20 +36,22 @@ tab = $('#current_tab').val()
 $("#select_for_arm_#{arm_id}").replaceWith("<%= j render '/study_schedule/visit_group_page_select', arm: @arm, page: @current_page.to_i %>")
 $(".selectpicker").selectpicker()
 
-<% if on_current_page?(@current_page, @visit_group.position) %>
-# Overwrite the visit_groups
-$(".visit_groups_for_#{arm_id}").html("<%= j render '/study_schedule/visit_groups', arm: @arm, visit_groups: @visit_groups, tab: @schedule_tab %>")
-# Overwrite the check columns
-$(".check_columns_for_arm_#{arm_id}").html("<%= j render '/study_schedule/check_visit_columns', visit_groups: @visit_groups, tab: @schedule_tab %>")
-# Overwrite the visits
-<% @arm.line_items.each do |line_item| %>
-$(".visit_for_line_item_<%= line_item.id %>").last().after('<div id="placeholderElement"></div>')
-placeholder_element = $('#placeholderElement')
-placeholder_element.siblings('.visit').remove()
-placeholder_element.after("<%= j render '/study_schedule/visits', line_item: line_item, page: @current_page.to_i, tab: @schedule_tab %>")
-placeholder_element.remove()
-<% end %>
-#Adjust sticky headers
-adjustCalendarHeaders()
-<% end %>
+
+# on_current_page? checks if the visit_group should be on the current page after update, also need to check if it's there before it was updated
+if <%= on_current_page?(@current_page, @visit_group.position) %> || $('#visit-name-display-<%= @visit_group.id %>').length
+  # Overwrite the visit_groups
+  $(".visit_groups_for_#{arm_id}").html("<%= j render '/study_schedule/visit_groups', arm: @arm, visit_groups: @visit_groups, tab: @schedule_tab %>")
+  # Overwrite the check columns
+  $(".check_columns_for_arm_#{arm_id}").html("<%= j render '/study_schedule/check_visit_columns', visit_groups: @visit_groups, tab: @schedule_tab %>")
+  # Overwrite the visits
+  <% @arm.line_items.each do |line_item| %>
+  $(".visit_for_line_item_<%= line_item.id %>").last().after('<div id="placeholderElement"></div>')
+  placeholder_element = $('#placeholderElement')
+  placeholder_element.siblings('.visit').remove()
+  placeholder_element.after("<%= j render '/study_schedule/visits', line_item: line_item, page: @current_page.to_i, tab: @schedule_tab %>")
+  placeholder_element.remove()
+  <% end %>
+  #Adjust sticky headers
+  adjustCalendarHeaders()
+
 <% end %>


### PR DESCRIPTION
[#176056664](https://www.pivotaltracker.com/story/show/176056664)

Fixed an issue where moving a visit group to a calendar page that isn't the current page doesn't move the visit group from the view. This was happening because we only checked if the visit group was on the current calendar page based on its updated position values, not whether or not it was on the calendar before calling update.

This fix did not need to be applied to `visit_groups/create.js.coffee` or `visit_gorups/destroy.js.coffee`. When a visit group is created, it would never already exist on the calendar. If a visit group is destroyed, the position is never updated, so `on_current_page?` would have been the same before and after calling destroy.

However, if creating or destroying a visit group that's on a page before the current page, the calendar needs to be refreshed. In this case, all of the visible visit groups would be either shifted right or left one place and wouldn't match the updated page selectpicker. A new helper method `before_current_page?` was added to accomplish this check.