### PR TITLE
SAW - BS4: Fixed horizontal form styling for errors on numerous forms

### DIFF
--- a/app/assets/stylesheets/custom/bootstrap-custom.scss
+++ b/app/assets/stylesheets/custom/bootstrap-custom.scss
@@ -794,33 +794,31 @@ nav.navbar {
 /// Utilities ///
 /////////////////
 
-.form-group, .form-row {
-  &.is-valid {
-    .bootstrap-select .dropdown-toggle, .toggle, .input-group .input-group-text {
-      border: 1px solid theme-color('success') !important;
-    }
-
-    label {
-      color: theme-color('success');
-    }
-
-    .form-control, .custom-select {
-      @extend .is-valid;
-    }
+.is-valid {
+  .bootstrap-select .dropdown-toggle, .toggle, .input-group .input-group-text {
+    border: 1px solid theme-color('success') !important;
   }
 
-  &.is-invalid {
-    .bootstrap-select .dropdown-toggle, .toggle, .input-group .input-group-text {
-      border: 1px solid theme-color('danger') !important;
-    }
+  label {
+    color: theme-color('success');
+  }
 
-    label {
-      color: theme-color('danger');
-    }
+  .form-control, .custom-select {
+    @extend .is-valid;
+  }
+}
 
-    .form-control, .custom-select {
-      @extend .is-invalid;
-    }
+.is-invalid {
+  .bootstrap-select .dropdown-toggle, .toggle, .input-group .input-group-text {
+    border: 1px solid theme-color('danger') !important;
+  }
+
+  label {
+    color: theme-color('danger');
+  }
+
+  .form-control, .custom-select {
+    @extend .is-invalid;
   }
 }
 

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -46,6 +46,8 @@ class AppointmentsController < ApplicationController
     @protocols_participant = ProtocolsParticipant.find(custom_appointment_params[:protocols_participant_id])
     if @appointment.valid?
       @appointment.save
+    else
+      @errors = @appointment.errors
     end
   end
 

--- a/app/views/appointments/_form.html.haml
+++ b/app/views/appointments/_form.html.haml
@@ -29,25 +29,29 @@
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group.row.align-items-center
-          = f.label "name", Appointment.human_attribute_name(:name), class: "control-label required col-sm-4 mb-0"
-          .col-sm-8
-            = f.text_field :name, {class: 'form-control'}
-        .form-group.row.align-items-center
-          = f.label "position", Appointment.human_attribute_name(:position), class: "control-label col-sm-4 mb-0"
-          .col-sm-8
-            = f.select "position", options_from_collection_for_select(appointment.arm.appointments.where(protocols_participant_id: appointment.protocols_participant_id), 'position', 'insertion_name') << app_add_as_last_option(appointment), {include_blank: ''}, class: "form-control selectpicker visit-group-position"
+        .form-group
+          .row.align-items-center
+            = f.label "name", Appointment.human_attribute_name(:name), class: "control-label required col-sm-4 mb-0"
+            .col-sm-8
+              = f.text_field :name, {class: 'form-control'}
+        .form-group
+          .row.align-items-center
+            = f.label "position", Appointment.human_attribute_name(:position), class: "control-label col-sm-4 mb-0"
+            .col-sm-8
+              = f.select "position", options_from_collection_for_select(appointment.arm.appointments.where(protocols_participant_id: appointment.protocols_participant_id), 'position', 'insertion_name') << app_add_as_last_option(appointment), {include_blank: ''}, class: "form-control selectpicker visit-group-position"
         = f.fields_for :notes, note do |nf|
           = nf.hidden_field :kind
           = nf.hidden_field :identity_id, value: current_identity.id
-          .form-group.row.align-items-center
-            = nf.label "reason", t(:notes)[:reason], class: "control-label col-sm-4 mb-0"
-            .col-sm-8
-              = nf.select :reason, Appointment::NOTABLE_REASONS, {include_blank: ''}, class: "form-control selectpicker"
-          .form-group.row.align-items-center
-            = nf.label "comment", t(:notes)[:comment], class: "control-label col-sm-4 mb-0"
-            .col-sm-8
-              = nf.text_area :comment, {class: 'form-control', rows: "6"}
+          .form-group
+            .row.align-items-center
+              = nf.label "reason", t(:notes)[:reason], class: "control-label col-sm-4 mb-0"
+              .col-sm-8
+                = nf.select :reason, Appointment::NOTABLE_REASONS, {include_blank: ''}, class: "form-control selectpicker"
+          .form-group
+            .row.align-items-center
+              = nf.label "comment", t(:notes)[:comment], class: "control-label col-sm-4 mb-0"
+              .col-sm-8
+                = nf.text_area :comment, {class: 'form-control', rows: "6"}
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/appointments/create.js.coffee
+++ b/app/views/appointments/create.js.coffee
@@ -18,8 +18,14 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-<% if !(@appointment.errors.empty?) %>
-$("#appointment_modal_errors").html("<%= escape_javascript(render(partial: 'modal_errors', locals: {errors: @appointment.errors})) %>")
+<% if @errors %>
+$("[name^='custom_appointment']:not([type='hidden'])").parents('.form-group').removeClass('is-invalid').addClass('is-valid')
+$('.form-error').remove()
+<% @errors.messages.each do |attr, messages| %>
+<% messages.each do |message| %>
+$("[name='custom_appointment[<%= attr.to_s %>]']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% end %>
+<% end %>
 <% else %>
 $('#appointmentsList').replaceWith("<%= j render '/protocols_participants/appointments', protocols_participant: @protocols_participant %>")
 $("#modalContainer").modal 'hide'

--- a/app/views/procedures/_edit.html.haml
+++ b/app/views/procedures/_edit.html.haml
@@ -30,27 +30,30 @@
           %span{ aria: { hidden: 'true' } } &times;
 
       .modal-body
-        .form-group.row.align-items-center
-          = f.label 'assignee_id', t('task.assignee_name'), class: 'required control-label mb-0 col-sm-4'
-          .col-sm-8
-            = f.select :assignee_id, options_from_collection_for_select(clinical_providers.map(&:identity).sort_by!{ |i| i.last_name.downcase }.uniq, 'id', 'full_name'), { include_blank: true }, class: 'form-control selectpicker'
-        .form-group.row.align-items-center
-          = f.label 'follow_up_date', t('task.due_at'), class: 'required control-label mb-0 col-sm-4'
-          .col-sm-8
-            .input-group.datetimepicker.date{ id: 'dueAtDatePicker', data: { target_input: 'nearest' } }
-              = f.text_field :due_at, class: 'datetimepicker-input form-control', data: { target: '#dueAtDatePicker' }
-              .input-group-append{ data: { toggle: 'datetimepicker', target: '#dueAtDatePicker' } }
-                %span.input-group-text
-                  = icon('fas', 'calendar-alt')
-        .form-group.row.align-items-center
-          = f.fields_for :notes, Note.new do |nf|
-            = nf.hidden_field :notable_type, value: 'Procedure'
-            = nf.hidden_field :notable_id, value: procedure.id
-            = nf.hidden_field :kind, value: 'followup'
-
-            = nf.label 'comment', t(:notes)[:comment], class: 'required control-label mb-0 col-sm-4'
+        .form-group
+          .row.align-items-center
+            = f.label 'assignee_id', t('task.assignee_name'), class: 'required control-label mb-0 col-sm-4'
             .col-sm-8
-              = nf.text_area :comment, { class: 'form-control', rows: '6' }
+              = f.select :assignee_id, options_from_collection_for_select(clinical_providers.map(&:identity).sort_by!{ |i| i.last_name.downcase }.uniq, 'id', 'full_name'), { include_blank: true }, class: 'form-control selectpicker'
+        .form-group
+          .row.align-items-center
+            = f.label 'follow_up_date', t('task.due_at'), class: 'required control-label mb-0 col-sm-4'
+            .col-sm-8
+              .input-group.datetimepicker.date{ id: 'dueAtDatePicker', data: { target_input: 'nearest' } }
+                = f.text_field :due_at, class: 'datetimepicker-input form-control', data: { target: '#dueAtDatePicker' }
+                .input-group-append{ data: { toggle: 'datetimepicker', target: '#dueAtDatePicker' } }
+                  %span.input-group-text
+                    = icon('fas', 'calendar-alt')
+        .form-group
+          .row.align-items-center
+            = f.fields_for :notes, Note.new do |nf|
+              = nf.hidden_field :notable_type, value: 'Procedure'
+              = nf.hidden_field :notable_id, value: procedure.id
+              = nf.hidden_field :kind, value: 'followup'
+
+              = nf.label 'comment', t(:notes)[:comment], class: 'control-label mb-0 col-sm-4'
+              .col-sm-8
+                = nf.text_area :comment, { class: 'form-control', rows: '6' }
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/reports/_project_summary_report.html.haml
+++ b/app/views/reports/_project_summary_report.html.haml
@@ -31,27 +31,31 @@
         = render partial: 'required_fields'
         .col-md-12.mt-3
           = hidden_field_tag "report_type", report_type
-          .form-group.row.align-items-center
-            =label_tag "title", t(:documents)[:title], class: "control-label required col-sm-4 mb-0"
-            .col-sm-8= text_field_tag "title", title, class: "form-control"
-          .form-group.row.align-items-center
-            = label_tag "start_date", t(:reports)[:start_date], class: "control-label required col-sm-4 mb-0"
-            .input-group.datetimepicker.date.col-sm-8{ id: 'start_date', data: {target_input: 'nearest' }}
-              = text_field_tag "start_date", nil, class: "form-control datetimepicker-input", readonly: true, data: { target:"#start_date", toggle:"datetimepicker" }
-              .input-group-append{ data: { toggle: 'datetimepicker', target: '#start_date' }}
-                .input-group-text
-                  %span.far.fa-calendar
-          .form-group.row.align-items-center
-            = label_tag "end_date", t(:reports)[:end_date], class: "control-label required col-sm-4 mb-0"
-            .input-group.datetimepicker.date.col-sm-8{ id: 'end_date', data: {target_input: 'nearest'}}
-              = text_field_tag "end_date", nil, class: "form-control datetimepicker-input", readonly: true, data: { target:"#end_date", toggle:"datetimepicker" }
-              .input-group-append{ data: { toggle: 'datetimepicker', target: '#end_date' }}
-                .input-group-text
-                  %span.far.fa-calendar
-          .form-group.protocols-group.row.align-items-center
-            = label_tag "protocol", t(:reports)[:protocols], class: "control-label required col-sm-4 mb-0"
-            .col-sm-8#protocol_section.background_load
-              %i.fas.fa-cog.fa-spin
+          .form-group
+            .row.align-items-center
+              = label_tag "title", t(:documents)[:title], class: "control-label required col-sm-4 mb-0"
+              .col-sm-8= text_field_tag "title", title, class: "form-control"
+          .form-group
+            .row.align-items-center
+              = label_tag "start_date", t(:reports)[:start_date], class: "control-label required col-sm-4 mb-0"
+              .input-group.datetimepicker.date.col-sm-8{ id: 'start_date', data: {target_input: 'nearest' }}
+                = text_field_tag "start_date", nil, class: "form-control datetimepicker-input", readonly: true, data: { target:"#start_date", toggle:"datetimepicker" }
+                .input-group-append{ data: { toggle: 'datetimepicker', target: '#start_date' }}
+                  .input-group-text
+                    %span.far.fa-calendar
+          .form-group
+            .row.align-items-center
+              = label_tag "end_date", t(:reports)[:end_date], class: "control-label required col-sm-4 mb-0"
+              .input-group.datetimepicker.date.col-sm-8{ id: 'end_date', data: {target_input: 'nearest'}}
+                = text_field_tag "end_date", nil, class: "form-control datetimepicker-input", readonly: true, data: { target:"#end_date", toggle:"datetimepicker" }
+                .input-group-append{ data: { toggle: 'datetimepicker', target: '#end_date' }}
+                  .input-group-text
+                    %span.far.fa-calendar
+          .form-group.protocols-group
+            .row.align-items-center
+              = label_tag "protocol", t(:reports)[:protocols], class: "control-label required col-sm-4 mb-0"
+              .col-sm-8#protocol_section.background_load
+                %i.fas.fa-cog.fa-spin
       .modal-footer
         .center-block
           %button.btn.btn-secondary{type: 'button', data: {dismiss: 'modal'}}

--- a/app/views/study_schedule/management/manage_arms/_add_arm_form.html.haml
+++ b/app/views/study_schedule/management/manage_arms/_add_arm_form.html.haml
@@ -29,22 +29,26 @@
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group.row.align-items-center
-          = f.label 'name', t('arm.name'), class: 'control-label required col-sm-4 mb-0'
-          .col-sm-8
-            = f.text_field :name, { class: 'form-control' }
-        .form-group.row.align-items-center
-          = f.label 'subject_count', t('arm.subject_count'), class: 'control-label required col-sm-4 mb-0'
-          .col-sm-8
-            = f.text_field :subject_count, { class: 'form-control' }
-        .form-group.row.align-items-center
-          = f.label 'visit_count', t('arm.visit_count'), class: 'control-label required col-sm-4 mb-0'
-          .col-sm-8
-            = f.text_field :visit_count, { class: 'form-control' }
-        .form-group.row.align-items-center
-          = label_tag 'service_ids', t('services.objects'), class: 'control-label col-sm-4 mb-0'
-          .col-sm-8
-            = select_tag 'services[]', options_from_collection_for_select(services, 'id' , 'name'), { class: 'form-control selectpicker', multiple: '', title: 'Please Select Services', 'data-selected-text-format' => 'count>2'}
+        .form-group
+          .row.align-items-center
+            = f.label 'name', t('arm.name'), class: 'control-label required col-sm-4 mb-0'
+            .col-sm-8
+              = f.text_field :name, { class: 'form-control' }
+        .form-group
+          .row.align-items-center
+            = f.label 'subject_count', t('arm.subject_count'), class: 'control-label required col-sm-4 mb-0'
+            .col-sm-8
+              = f.text_field :subject_count, { class: 'form-control' }
+        .form-group
+          .row.align-items-center
+            = f.label 'visit_count', t('arm.visit_count'), class: 'control-label required col-sm-4 mb-0'
+            .col-sm-8
+              = f.text_field :visit_count, { class: 'form-control' }
+        .form-group
+          .row.align-items-center
+            = label_tag 'service_ids', t('services.objects'), class: 'control-label col-sm-4 mb-0'
+            .col-sm-8
+              = select_tag 'services[]', options_from_collection_for_select(services, 'id' , 'name'), { class: 'form-control selectpicker', multiple: '', title: 'Please Select Services', 'data-selected-text-format' => 'count>2'}
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/study_schedule/management/manage_arms/_navigate_arm_form.html.haml
+++ b/app/views/study_schedule/management/manage_arms/_navigate_arm_form.html.haml
@@ -30,19 +30,22 @@
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
         #navigateArmFormBody{ data: { intended_action: intended_action } }
-          .form-group.row.align-items-center
-            = label_tag 'arm_form_label', t('arm.object'), class: 'required control-label mb-0 col-sm-4'
-            .col-sm-8
-              = select_tag 'arm_form_select', options_from_collection_for_select(protocol_arms, 'id', 'name', arm.id), class: 'selectpicker form-control'
+          .form-group
+            .row.align-items-center
+              = label_tag 'arm_form_label', t('arm.object'), class: 'required control-label mb-0 col-sm-4'
+              .col-sm-8
+                = select_tag 'arm_form_select', options_from_collection_for_select(protocol_arms, 'id', 'name', arm.id), class: 'selectpicker form-control'
           - if edit_action
-            .form-group.row.align-items-center
-              = f.label 'name', t('arm.name'), class: 'required control-label mb-0 col-sm-4'
-              .col-sm-8
-                = f.text_field :name, {class: 'form-control'}
-            .form-group.row.align-items-center
-              = f.label 'subject_count', t('arm.subject_count'), class: 'required control-label mb-0 col-sm-4'
-              .col-sm-8
-                = f.text_field :subject_count, {class: 'form-control'}
+            .form-group
+              .row.align-items-center
+                = f.label 'name', t('arm.name'), class: 'required control-label mb-0 col-sm-4'
+                .col-sm-8
+                  = f.text_field :name, {class: 'form-control'}
+            .form-group
+              .row.align-items-center
+                = f.label 'subject_count', t('arm.subject_count'), class: 'required control-label mb-0 col-sm-4'
+                .col-sm-8
+                  = f.text_field :subject_count, {class: 'form-control'}
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/study_schedule/management/manage_services/_add_line_items_form.html.haml
+++ b/app/views/study_schedule/management/manage_services/_add_line_items_form.html.haml
@@ -28,14 +28,16 @@
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group.row.align-items-center
-          = label_tag "add_service_id", t(:services)[:object], class: 'control-label mb-0 col-sm-4'
-          .col-sm-8
-            = select_tag "add_service_id", options_from_collection_for_select(services, 'id' , 'name'), class: "form-control selectpicker"
-        .form-group.row.align-items-center
-          = label_tag "add_service_arm_ids_and_pages", t(:arm)[:objects], class: "required control-label mb-0 col-sm-4"
-          .col-sm-8
-            = select_tag "add_service_arm_ids_and_pages[]", create_line_items_options(page_hash), { class: "form-control selectpicker", multiple: "", title: "Please Select Arms", 'data-selected-text-format' => 'count>2'}
+        .form-group
+          .row.align-items-center
+            = label_tag "add_service_id", t(:services)[:object], class: 'control-label mb-0 col-sm-4'
+            .col-sm-8
+              = select_tag "add_service_id", options_from_collection_for_select(services, 'id' , 'name'), class: "form-control selectpicker"
+        .form-group
+          .row.align-items-center
+            = label_tag "add_service_arm_ids_and_pages", t(:arm)[:objects], class: "required control-label mb-0 col-sm-4"
+            .col-sm-8
+              = select_tag "add_service_arm_ids_and_pages[]", create_line_items_options(page_hash), { class: "form-control selectpicker", multiple: "", title: "Please Select Arms", 'data-selected-text-format' => 'count>2'}
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/study_schedule/management/manage_services/_change_service_form.html.haml
+++ b/app/views/study_schedule/management/manage_services/_change_service_form.html.haml
@@ -28,10 +28,11 @@
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group.row.align-items-center
-          = f.label 'service', t('line_item.service'), class: 'control-label mb-0 col-sm-4'
-          .col-sm-8
-            = f.select 'service_id', options_from_collection_for_select(line_item.service.organization.inclusive_child_services(:per_participant), 'id', 'name', line_item.service_id), {}, class: 'form-control selectpicker'
+        .form-group
+          .row.align-items-center
+            = f.label 'service', t('line_item.service'), class: 'control-label mb-0 col-sm-4'
+            .col-sm-8
+              = f.select 'service_id', options_from_collection_for_select(line_item.service.organization.inclusive_child_services(:per_participant), 'id', 'name', line_item.service_id), {}, class: 'form-control selectpicker'
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t('actions.close')

--- a/app/views/study_schedule/management/manage_services/_remove_line_items_form.html.haml
+++ b/app/views/study_schedule/management/manage_services/_remove_line_items_form.html.haml
@@ -27,10 +27,11 @@
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group.row.align-items-center
-          = label_tag :line_item_ids, t(:services)[:objects], class: 'control-label mb-0 col-sm-4'
-          .col-sm-8
-            = select_tag :line_item_ids, grouped_options_for_select(line_items.group_by{ |li| li.arm.name }.map{ |arm, lis| [arm, lis.map{ |li| [li.name, li.id] }] }), class: 'form-control selectpicker', multiple: true
+        .form-group
+          .row.align-items-center
+            = label_tag :line_item_ids, t(:services)[:objects], class: 'control-label mb-0 col-sm-4'
+            .col-sm-8
+              = select_tag :line_item_ids, grouped_options_for_select(line_items.group_by{ |li| li.arm.name }.map{ |arm, lis| [arm, lis.map{ |li| [li.name, li.id] }] }), class: 'form-control selectpicker', multiple: true
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/study_schedule/management/manage_visits/_add_visit_form.html.haml
+++ b/app/views/study_schedule/management/manage_visits/_add_visit_form.html.haml
@@ -29,30 +29,36 @@
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group.row.align-items-center
-          = f.label "arm_id", t('visit_groups.arm'), class: 'control-label col-sm-4 mb-0'
-          .col-sm-8
-            = f.select :arm_id, options_from_collection_for_select(protocol.arms,'id','name', arm.id), { include_blank: false }, class: "form-control selectpicker"
-        .form-group.row.align-items-center
-          = f.label "name", t('visit_groups.name'), class: 'required control-label col-sm-4 mb-0'
-          .col-sm-8
-            = f.text_field :name, { class: 'form-control' }
-        .form-group.row.align-items-center
-          = f.label "day", t('visit_groups.day'), class: "control-label col-sm-4 mb-0 #{ENV.fetch('USE_EPIC'){nil} == 'false' ? '' : 'required'}"
-          .col-sm-8
+        .form-group
+          .row.align-items-center
+            = f.label "arm_id", t('visit_groups.arm'), class: 'control-label col-sm-4 mb-0'
+            .col-sm-8
+              = f.select :arm_id, options_from_collection_for_select(protocol.arms,'id','name', arm.id), { include_blank: false }, class: "form-control selectpicker"
+        .form-group
+          .row.align-items-center
+            = f.label "name", t('visit_groups.name'), class: 'required control-label col-sm-4 mb-0'
+            .col-sm-8
+              = f.text_field :name, { class: 'form-control' }
+        .form-group
+          .row.align-items-center
+            = f.label "day", t('visit_groups.day'), class: "control-label col-sm-4 mb-0 #{ENV.fetch('USE_EPIC'){nil} == 'false' ? '' : 'required'}"
+            .col-sm-8
             = f.text_field :day, { class: 'form-control', maxlength: 4 }
-        .form-group.row.align-items-center
-          = f.label "position", t('visit_groups.position'), class: 'control-label col-sm-4 mb-0'
-          .col-sm-8
-            = f.select :position, options_for_select(insert_to_position_options(arm.visit_groups)), { include_blank: '' }, class: "form-control selectpicker visit-group-position"
-        .form-group.row.align-items-center
-          = f.label "window_before", t('visit_groups.window_before'), class: 'control-label col-sm-4 mb-0'
-          .col-sm-8
-            = f.text_field :window_before, { class: 'form-control' }
-        .form-group.row.align-items-center
-          = f.label "window_after", t('visit_groups.window_after'), class: 'control-label col-sm-4 mb-0'
-          .col-sm-8
-            = f.text_field :window_after, { class: 'form-control' }
+        .form-group
+          .row.align-items-center
+            = f.label "position", t('visit_groups.position'), class: 'control-label col-sm-4 mb-0'
+            .col-sm-8
+              = f.select :position, options_for_select(insert_to_position_options(arm.visit_groups)), { include_blank: '' }, class: "form-control selectpicker visit-group-position"
+        .form-group
+          .row.align-items-center
+            = f.label "window_before", t('visit_groups.window_before'), class: 'control-label col-sm-4 mb-0'
+            .col-sm-8
+              = f.text_field :window_before, { class: 'form-control' }
+        .form-group
+          .row.align-items-center
+            = f.label "window_after", t('visit_groups.window_after'), class: 'control-label col-sm-4 mb-0'
+            .col-sm-8
+              = f.text_field :window_after, { class: 'form-control' }
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/study_schedule/management/manage_visits/_navigate_visit_form.html.haml
+++ b/app/views/study_schedule/management/manage_visits/_navigate_visit_form.html.haml
@@ -32,35 +32,42 @@
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
         #navigateVisitFormBody{data: { intended_action: intended_action }}
-          .form-group.row.align-items-center
-            = label_tag 'visit_group_arm_form_label', t('arm.object'), class: 'control-label mb-0 col-sm-4'
-            .col-sm-8
-              = select_tag 'visit_group_arm_form_select', options_from_collection_for_select(protocol.arms, 'id', 'name', arm.id), class: 'selectpicker form-control', attribute: 'arm' 
-          .form-group.row.align-items-center
-            = label_tag 'visit_group_form_label', t('visit.object'), class: 'control-label mb-0 col-sm-4'
-            .col-sm-8
-              = select_tag 'visit_group_form_select', options_for_select(edit_visit_options(arm.visit_groups), visit_group.id), class: 'selectpicker form-control', attribute: 'visit_group'
+          .form-group
+            .row.align-items-center
+              = label_tag 'visit_group_arm_form_label', t('arm.object'), class: 'control-label mb-0 col-sm-4'
+              .col-sm-8
+                = select_tag 'visit_group_arm_form_select', options_from_collection_for_select(protocol.arms, 'id', 'name', arm.id), class: 'selectpicker form-control', attribute: 'arm' 
+          .form-group
+            .row.align-items-center
+              = label_tag 'visit_group_form_label', t('visit.object'), class: 'control-label mb-0 col-sm-4'
+              .col-sm-8
+                = select_tag 'visit_group_form_select', options_for_select(edit_visit_options(arm.visit_groups), visit_group.id), class: 'selectpicker form-control', attribute: 'visit_group'
           - if edit_action
-            .form-group.row.align-items-center
-              = f.label 'name', t('visit_groups.name'), class: 'required control-label mb-0 col-sm-4'
-              .col-sm-8
-                = f.text_field :name, {class: 'form-control'}
-            .form-group.row.align-items-center
-              = f.label 'day', t('visit_groups.day'), class: "control-label mb-0 col-sm-4#{ENV.fetch('USE_EPIC'){nil} == 'false' ? '' : 'required'}"
-              .col-sm-8
-                = f.text_field :day, {class: 'form-control', maxlength: 4}
-            .form-group.row.align-items-center
-              = f.label 'position', t('visit_groups.position'), class: 'control-label mb-0 col-sm-4'
-              .col-sm-8
-                = f.select :position, options_for_select(move_to_position_options_for(visit_group), visit_group.position), {}, class: 'form-control selectpicker'
-            .form-group.row.align-items-center
-              = f.label 'window_before', t('visit_groups.window_before'), class: 'control-label mb-0 col-sm-4'
-              .col-sm-8
-                = f.text_field :window_before, {class: 'form-control'}
-            .form-group.row.align-items-center
-              = f.label 'window_after', t('visit_groups.window_after'), class: 'control-label mb-0 col-sm-4'
-              .col-sm-8
-                = f.text_field :window_after, {class: 'form-control'}
+            .form-group
+              .row.align-items-center
+                = f.label 'name', t('visit_groups.name'), class: 'required control-label mb-0 col-sm-4'
+                .col-sm-8
+                  = f.text_field :name, {class: 'form-control'}
+            .form-group
+              .row.align-items-center
+                = f.label 'day', t('visit_groups.day'), class: "control-label mb-0 col-sm-4#{ENV.fetch('USE_EPIC'){nil} == 'false' ? '' : 'required'}"
+                .col-sm-8
+                  = f.text_field :day, {class: 'form-control', maxlength: 4}
+            .form-group
+              .row.align-items-center
+                = f.label 'position', t('visit_groups.position'), class: 'control-label mb-0 col-sm-4'
+                .col-sm-8
+                  = f.select :position, options_for_select(move_to_position_options_for(visit_group), visit_group.position), {}, class: 'form-control selectpicker'
+            .form-group
+              .row.align-items-center
+                = f.label 'window_before', t('visit_groups.window_before'), class: 'control-label mb-0 col-sm-4'
+                .col-sm-8
+                  = f.text_field :window_before, {class: 'form-control'}
+            .form-group
+              .row.align-items-center
+                = f.label 'window_after', t('visit_groups.window_after'), class: 'control-label mb-0 col-sm-4'
+                .col-sm-8
+                  = f.text_field :window_after, {class: 'form-control'}
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -29,22 +29,25 @@
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group.row.align-items-center
-          = f.label 'assignee_id', t('task.assignee_name'), class: 'required control-label col-sm-4 mb-0'
-          .col-sm-8
-            = f.select :assignee_id, options_from_collection_for_select(clinical_providers, 'id', 'full_name'), { include_blank: true }, class: 'form-control selectpicker'
-        .form-group.row.align-items-center
-          = f.label 'follow_up_date', Task.human_attribute_name(:due_at), class: 'required control-label col-sm-4 mb-0'
-          .col-sm-8
-            .input-group.datetimepicker.date{ id: 'dueAtDatePicker', data: { target_input: 'nearest' } }
-              = f.text_field :due_at, class: 'datetimepicker-input form-control', data: { target: '#dueAtDatePicker' }
-              .input-group-append{ data: { toggle: 'datetimepicker', target: '#dueAtDatePicker' } }
-                %span.input-group-text
-                  = icon('fas', 'calendar-alt')
-        .form-group.row.align-items-center
-          = f.label 'task_body', Task.human_attribute_name(:body), class: 'control-label col-sm-4 mb-0'
-          .col-sm-8
-            = f.text_area :body, { class: 'form-control', rows: 4 }
+        .form-group
+          .row.align-items-center
+            = f.label 'assignee_id', t('task.assignee_name'), class: 'required control-label col-sm-4 mb-0'
+            .col-sm-8
+              = f.select :assignee_id, options_from_collection_for_select(clinical_providers, 'id', 'full_name'), { include_blank: true }, class: 'form-control selectpicker'
+        .form-group
+          .row.align-items-center
+            = f.label 'follow_up_date', Task.human_attribute_name(:due_at), class: 'required control-label col-sm-4 mb-0'
+            .col-sm-8
+              .input-group.datetimepicker.date{ id: 'dueAtDatePicker', data: { target_input: 'nearest' } }
+                = f.text_field :due_at, class: 'datetimepicker-input form-control', data: { target: '#dueAtDatePicker' }
+                .input-group-append{ data: { toggle: 'datetimepicker', target: '#dueAtDatePicker' } }
+                  %span.input-group-text
+                    = icon('fas', 'calendar-alt')
+        .form-group
+          .row.align-items-center
+            = f.label 'task_body', Task.human_attribute_name(:body), class: 'control-label col-sm-4 mb-0'
+            .col-sm-8
+              = f.text_area :body, { class: 'form-control', rows: 4 }
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/tasks/_task_reschedule_modal.html.haml
+++ b/app/views/tasks/_task_reschedule_modal.html.haml
@@ -27,14 +27,15 @@
         %button.close{ type: 'button', value: '', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group.row.align-items-center
-          = f.label 'follow_up_date', Task.human_attribute_name(:due_at), class: 'required control-label mb-0 col-sm-4'
-          .col-sm-8
-            .input-group.datetimepicker.date{ id: 'dueAtDatePicker', data: { target_input: 'nearest' } }
-              = f.text_field :due_at, class: 'datetimepicker-input form-control', data: { target: '#dueAtDatePicker' }
-              .input-group-append{ data: { toggle: 'datetimepicker', target: '#dueAtDatePicker' } }
-                %span.input-group-text
-                  = icon('fas', 'calendar-alt')
+        .form-group
+          .row.align-items-center
+            = f.label 'follow_up_date', Task.human_attribute_name(:due_at), class: 'required control-label mb-0 col-sm-4'
+            .col-sm-8
+              .input-group.datetimepicker.date{ id: 'dueAtDatePicker', data: { target_input: 'nearest' } }
+                = f.text_field :due_at, class: 'datetimepicker-input form-control', data: { target: '#dueAtDatePicker' }
+                .input-group-append{ data: { toggle: 'datetimepicker', target: '#dueAtDatePicker' } }
+                  %span.input-group-text
+                    = icon('fas', 'calendar-alt')
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]


### PR DESCRIPTION
Fixes some issues from [#176056664](https://www.pivotaltracker.com/story/show/176056664) (error styling, error placement text and icons beside dropdowns) and [#176057388](https://www.pivotaltracker.com/story/show/176057388) (comment required when it shouldn't be)

In fixing the form styling for [#176056664](https://www.pivotaltracker.com/story/show/176056664) I noticed multiple inline forms using small error text were also not styled nicely. I went back and found as many of them as I could to make sure the styling was correct (`.row` is nested under the form group so it doesn't remove padding for the `small` containing error text)