### PR TITLE
SAW - BS4 Participant Details and Notes Button Bugs

### DIFF
--- a/app/controllers/protocols_participants_controller.rb
+++ b/app/controllers/protocols_participants_controller.rb
@@ -55,6 +55,7 @@ class ProtocolsParticipantsController < ApplicationController
   def create
     respond_to :js
     @prot_part = @protocol.protocols_participants.create(participant_id: params[:participant_id])
+    @prot_part.current_identity = current_identity
     @prot_part.update_attribute(:arm, @protocol.arms.first) if @protocol.arms.count == 1
     flash[:success] = t('protocols_participants.flash.updated')
   end

--- a/app/helpers/protocols_participant_helper.rb
+++ b/app/helpers/protocols_participant_helper.rb
@@ -76,7 +76,7 @@ module ProtocolsParticipantHelper
   end
 
   def protocols_participant_details_button(protocols_participant)
-    link_to participant_details_path(protocols_participant), remote: true, class: 'btn btn-sq btn-info mr-1 participant-details is-this-update', title: t('actions.details'), data: { toggle: 'tooltip' } do
+    link_to participant_details_path(protocols_participant.participant_id), remote: true, class: 'btn btn-sq btn-info mr-1 participant-details is-this-update', title: t('actions.details'), data: { toggle: 'tooltip' } do
       icon('fas', 'eye')
     end
   end

--- a/spec/models/protocols_participant_spec.rb
+++ b/spec/models/protocols_participant_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe ProtocolsParticipant, type: :model do
 
         expect(protocols_participant).to callback(:update_faye).after(:save)
       end
+
+      it 'should create a note when the arm is updated' do
+        notes_before_update = protocols_participant.participant.notes.count
+        arm2 = create(:arm, protocol_id: protocol.id)
+
+        protocols_participant.update(arm: arm2)
+        expect(protocols_participant.participant.notes.count).to eq(notes_before_update + 1)
+      end
     end
   end
 end


### PR DESCRIPTION
[#180104562](https://www.pivotaltracker.com/story/show/180104562)

Addressed two bugs:

1. The details button on a participant in the Participant Tracker didn't work because the protocols_participant object was passed to the details path helper instead of the participant itself.
2. The notes button would sometimes break because there were notes with `nil` identity_id. This shouldn't be the case at all. Notes were getting created without an identity when a participant is added to a protocol with only one arm. This was fixed by assigning the current_identity to the protocols_participant object in ProtocolsParticipantsController#create before assigning the arm if there's only one.

This PR **does not** do anything to fix existing notes without an identity id. However, this issue hasn't made it to production yet, and there are no notes in production or staging with `nil` identity_id. Since the only bad data exists in -d, those bad notes can simply be deleted in -d after this change has been deployed. Any time -d is refreshed, no new bad notes should be introduced so they don't need to be deleted again either.