### PR TITLE
fix multicomplete modal required comment field [#181343641]

### DIFF
--- a/app/controllers/multiple_procedures_controller.rb
+++ b/app/controllers/multiple_procedures_controller.rb
@@ -87,7 +87,7 @@ class MultipleProceduresController < ApplicationController
     @multiple_procedure_errors.store(:performer_id, t('multiple_procedures_modal.errors.performer_id')) if params[:performer_id].blank?
     @multiple_procedure_errors.store(:completed_date, t('multiple_procedures_modal.errors.completed_date')) if complete_status_detected? && params[:completed_date].blank?
     @multiple_procedure_errors.store(:reason, t('multiple_procedures_modal.errors.reason')) if incomplete_status_detected? && params[:reason].blank?
-    @multiple_procedure_errors.store(:comment, t('multiple_procedures_modal.errors.comment')) if incomplete_status_detected? && params[:comment].blank?
+    # @multiple_procedure_errors.store(:comment, t('multiple_procedures_modal.errors.comment')) if incomplete_status_detected? && params[:comment].blank?
 
     if @multiple_procedure_errors.empty?
       @multiple_procedure_errors = nil

--- a/app/views/multiple_procedures/_incomplete_all_modal.html.haml
+++ b/app/views/multiple_procedures/_incomplete_all_modal.html.haml
@@ -37,7 +37,7 @@
           = f.label 'reason', t('multiple_procedures_modal.reason'), class: 'required'
           = f.select :reason, options_for_select(Procedure::NOTABLE_REASONS), { include_blank: true }, class: 'selectpicker form-control'
         .form-group
-          = f.label "comment", t('notes.comment'), class: 'required'
+          = f.label "comment", t('notes.comment')
           = f.text_area :comment, class: 'form-control', id: 'comment', rows: 6
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181343641

Updated _incomplete_all_modal and multiple_procedures_controller to remove required field from modal.