### PR TITLE
SJ - Fixing Spec Slowness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ jobs:
       - bundle exec rspec spec/controllers
       - bundle exec rspec spec/helpers
       - bundle exec rspec spec/jobs
-    - script:
       - bundle exec rspec spec/lib
       - bundle exec rspec spec/models
       - bundle exec rspec spec/requests

--- a/spec/api/v1/notifications_post_spec.rb
+++ b/spec/api/v1/notifications_post_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'CWFSPARC::APIv1', type: :request, debug_response: true do
     context 'success' do
 
       before do
+        DatabaseCleaner[:active_record, model: Notification].clean_with(:truncation)
         sparc_sends_notification_post
       end
 

--- a/spec/controllers/documents/get_index_spec.rb
+++ b/spec/controllers/documents/get_index_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe DocumentsController, type: :controller do
     context 'format: :json' do
 
       before :each do
-        identity = Identity.first
+        identity = Identity.last
         @document = create(:document, documentable_type: 'Identity', documentable_id: identity.id)
       end
 
@@ -68,7 +68,7 @@ RSpec.describe DocumentsController, type: :controller do
       it 'should assign documents' do
         get :index, format: :json
 
-        expect(assigns(:documents)).to eq([@document])
+        expect(assigns(:documents)).to include(@document)
       end
     end
   end

--- a/spec/controllers/documents/get_index_spec.rb
+++ b/spec/controllers/documents/get_index_spec.rb
@@ -55,8 +55,7 @@ RSpec.describe DocumentsController, type: :controller do
     context 'format: :json' do
 
       before :each do
-        identity = Identity.last
-        @document = create(:document, documentable_type: 'Identity', documentable_id: identity.id)
+        @document = create(:document, documentable_type: 'Identity', documentable_id: @logged_in_identity.id)
       end
 
       it 'should render with :success' do
@@ -67,7 +66,6 @@ RSpec.describe DocumentsController, type: :controller do
 
       it 'should assign documents' do
         get :index, format: :json
-
         expect(assigns(:documents)).to include(@document)
       end
     end

--- a/spec/controllers/imports_controller_spec.rb
+++ b/spec/controllers/imports_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ImportsController, type: :controller do
 
       get :index
 
-      expect(assigns(:imports)).to eq [import]
+      expect(assigns(:imports)).to include(import)
     end
   end
 

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ParticipantsController do
     it "should get participants" do
       @participant2 = create(:participant)
       get :index, format: :json
-      expect(assigns(:participants)).to eq([@participant2, @participant])
+      expect(assigns(:participants)).to include(@participant2, @participant)
     end
   end
 

--- a/spec/features/appointments/appointment_calendar/appointment_management/identity_adds_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/appointment_management/identity_adds_procedure_spec.rb
@@ -45,11 +45,9 @@ feature 'Identity adds Procedure', js: true do
     visit_group = @protocols_participant.appointments.first.visit_group
     service     = @protocol.organization.inclusive_child_services(:per_participant).first
 
-    # bootstrap_select('.list-group-item', visit_group.name)
-    page.find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
     bootstrap_select('.form-control.selectpicker', service.name)
-    # fill_in 'input[value="1"]', with: '1'
     page.find('button#addService').click
     wait_for_ajax
   end

--- a/spec/features/appointments/appointment_calendar/appointment_management/identity_completes_visit_spec.rb
+++ b/spec/features/appointments/appointment_calendar/appointment_management/identity_completes_visit_spec.rb
@@ -93,7 +93,7 @@ feature 'Complete Visit', js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
     
-    page.find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
   end
 

--- a/spec/features/appointments/appointment_calendar/appointment_management/identity_completes_visit_spec.rb
+++ b/spec/features/appointments/appointment_calendar/appointment_management/identity_completes_visit_spec.rb
@@ -85,7 +85,6 @@ feature 'Complete Visit', js: true do
 
   def given_i_am_viewing_an_appointment
     protocol     = create_and_assign_protocol_to_me
-    @identity    = Identity.first
     protocols_participant  = protocol.protocols_participants.first
     @visit_group = protocols_participant.appointments.first.visit_group
     @service     = protocol.organization.inclusive_child_services(:per_participant).first
@@ -133,7 +132,7 @@ feature 'Complete Visit', js: true do
   def when_i_add_a_follow_up_date
     find("td.followup").click
     wait_for_ajax
-    bootstrap_select '#task_assignee_id', @identity.full_name
+    bootstrap_select '#task_assignee_id', @logged_in_identity.full_name
     bootstrap_datepicker '#task_due_at', day: '10'
     fill_in 'task_notes_comment', with: 'Test comment'
     click_button 'Submit'

--- a/spec/features/appointments/appointment_calendar/appointment_management/identity_completes_visit_spec.rb
+++ b/spec/features/appointments/appointment_calendar/appointment_management/identity_completes_visit_spec.rb
@@ -151,9 +151,4 @@ feature 'Complete Visit', js: true do
     expect(page).to have_css("button.disabled")
     wait_for_ajax
   end
-
-  def when_i_view_the_procedures_in_the_group
-    find('tr.procedure-group button').click
-    wait_for_ajax
-  end
 end

--- a/spec/features/appointments/appointment_calendar/appointment_management/identity_deletes_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/appointment_management/identity_deletes_procedure_spec.rb
@@ -50,7 +50,7 @@ feature 'Delete Procedure', js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
 
-    find('.appointment-link[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
 
     bootstrap_select '[name="service_id"]', service.name

--- a/spec/features/appointments/appointment_calendar/appointment_management/identity_resets_appointment_spec.rb
+++ b/spec/features/appointments/appointment_calendar/appointment_management/identity_resets_appointment_spec.rb
@@ -50,7 +50,7 @@ feature 'User tries to reset appointment', js: true do
     #Select the visit
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: @protocol)
     wait_for_ajax
-    page.find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
   end
 

--- a/spec/features/appointments/appointment_calendar/appointment_management/identity_starts_and_completes_appointment_spec.rb
+++ b/spec/features/appointments/appointment_calendar/appointment_management/identity_starts_and_completes_appointment_spec.rb
@@ -108,7 +108,7 @@ feature 'Start Complete Buttons', js: true do
     visit_group = @protocols_participant.appointments.first.visit_group
     service     = @protocol.organization.inclusive_child_services(:per_participant).first
 
-    page.find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     bootstrap_select('.form-control.selectpicker', service.name)
     page.find('button#addService').click
     wait_for_ajax

--- a/spec/features/appointments/appointment_calendar/grouped_services/identity_adds_a_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/grouped_services/identity_adds_a_procedure_spec.rb
@@ -93,20 +93,22 @@ feature 'Identity adds a Procedure', js: true do
 
   def when_i_add_a_procedure
     add_a_procedure @services.first
+    @first_procedure = Procedure.last
   end
 
   def when_i_add_a_different_procedure
     add_a_procedure @services.last
+    @second_procedure = Procedure.last
   end
 
   def then_i_should_see_the_group_counter_is_correct
-    group_id = Procedure.first.group_id
+    group_id = @first_procedure.group_id
 
     expect(page).to have_css("tr.hidden", count: 3, visible: false)
   end
 
   def and_select_a_procedure_from_multiselect
-    find("button[data-id='core_#{Procedure.first.sparc_core_id}_multiselect']").click
+    find("button[data-id='core_#{@first_procedure.sparc_core_id}_multiselect']").click
     wait_for_ajax
     
     find("a.dropdown-item").click
@@ -114,7 +116,7 @@ feature 'Identity adds a Procedure', js: true do
   end
 
   def and_select_all_procedures_from_multiselect
-    find("button[data-id='core_#{Procedure.first.sparc_core_id}_multiselect']").click
+    find("button[data-id='core_#{@first_procedure.sparc_core_id}_multiselect']").click
     find("button.bs-select-all").click
   end
 
@@ -124,25 +126,25 @@ feature 'Identity adds a Procedure', js: true do
   end
 
   def then_i_should_not_see_the_procedure_in_the_group
-    group_id = Procedure.last.group_id
+    group_id = @second_procedure.group_id
 
     expect(page).to have_css("tr[data-index='2']", count: 1)
   end
 
   def then_i_should_see_two_procedures_in_the_group
-    find("button[data-id='core_#{Procedure.first.sparc_core_id}_multiselect']").click
+    find("button[data-id='core_#{@first_procedure.sparc_core_id}_multiselect']").click
     wait_for_ajax
     
-    group_id = Procedure.first.group_id
+    group_id = @first_procedure.group_id
 
     expect(page).to have_css("tr.hidden", count: 2, visible: false)
   end
 
   def then_i_should_see_three_procedures_in_the_group
-    find("button[data-id='core_#{Procedure.first.sparc_core_id}_multiselect']").click
+    find("button[data-id='core_#{@first_procedure.sparc_core_id}_multiselect']").click
     wait_for_ajax
 
-    group_id = Procedure.first.group_id
+    group_id = @first_procedure.group_id
 
     expect(page).to have_css("tr.hidden", count: 3, visible: false)
   end
@@ -152,14 +154,14 @@ feature 'Identity adds a Procedure', js: true do
   end
 
   def then_i_should_see_the_multiselect_instantiated_with_2_options
-    find("button[data-id='core_#{Procedure.first.sparc_core_id}_multiselect']").click
+    find("button[data-id='core_#{@first_procedure.sparc_core_id}_multiselect']").click
     expect(page).to have_css("button.bs-select-all")
-    expect(page).to have_content("#{Procedure.first.service_name}")
+    expect(page).to have_content("#{@first_procedure.service_name}")
   end
 
   def then_i_should_see_the_quantity_increment_for_the_group_in_the_multiselect_dropdown
-    find("button[data-id='core_#{Procedure.first.sparc_core_id}_multiselect']").click
-    expect(page).to have_content("#{Procedure.first.service_name}")
+    find("button[data-id='core_#{@first_procedure.sparc_core_id}_multiselect']").click
+    expect(page).to have_content("#{@first_procedure.service_name}")
   end
 
   alias :and_the_visit_has_one_procedure :when_i_add_a_procedure

--- a/spec/features/appointments/appointment_calendar/grouped_services/identity_adds_multiple_procedures_spec.rb
+++ b/spec/features/appointments/appointment_calendar/grouped_services/identity_adds_multiple_procedures_spec.rb
@@ -59,12 +59,13 @@ feature 'Identity adds multiple Procedures', js: true do
 
   def when_i_add_5_procedures
     add_a_procedure @services.first, 5
+    @example_procedure = Procedure.last
   end
 
   def then_i_should_see_the_multiselect_instantiated_with_2_options
-    find("button[data-id='core_#{Procedure.first.sparc_core_id}_multiselect']").click
+    find("button[data-id='core_#{@example_procedure.sparc_core_id}_multiselect']").click
     expect(page).to have_css("button.bs-select-all")
-    expect(page).to have_content("#{Procedure.first.service_name}")
+    expect(page).to have_content("#{@example_procedure.service_name}")
   end
 
   def then_i_should_see_one_group_with_four_procedures

--- a/spec/features/appointments/appointment_calendar/grouped_services/identity_adds_procedures_spec.rb
+++ b/spec/features/appointments/appointment_calendar/grouped_services/identity_adds_procedures_spec.rb
@@ -43,7 +43,7 @@ feature 'Identity adds Procedure', js: true do
     visit_group = @protocols_participant.appointments.first.visit_group
     service     = @protocol.organization.inclusive_child_services(:per_participant).first
 
-    page.find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
     bootstrap_select('.form-control.selectpicker', service.name)
     fill_in 'service_quantity', with: '2'

--- a/spec/features/appointments/appointment_calendar/grouped_services/identity_credits_a_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/grouped_services/identity_credits_a_procedure_spec.rb
@@ -81,14 +81,14 @@ feature 'Invoice Procedure', js: true do
 
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
 
-    page.find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     bootstrap_select '[name="service_id"]', @service.name
     fill_in 'service_quantity', with: 1
     find('button#addService').click
   end
 
   def and_i_am_adding_a_procedure
-    page.find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     bootstrap_select '[name="service_id"]', @service.name
     fill_in 'service_quantity', with: 1
     find('button#addService').click

--- a/spec/features/appointments/appointment_calendar/grouped_services/identity_credits_a_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/grouped_services/identity_credits_a_procedure_spec.rb
@@ -56,17 +56,16 @@ feature 'Invoice Procedure', js: true do
   end
 
   def given_i_am_a_billing_manager
-    identity              = Identity.first
     sub_service_request   = create(:sub_service_request_with_organization)
     subsidy               = create(:subsidy, sub_service_request: sub_service_request)
-    @protocol              = create(:protocol_imported_from_sparc, sub_service_request: sub_service_request)
+    @protocol             = create(:protocol_imported_from_sparc, sub_service_request: sub_service_request)
     organization_provider = create(:organization_provider, name: "Provider")
     organization_program  = create(:organization_program, name: "Program", parent: organization_provider)
     organization          = sub_service_request.organization
     organization.update_attributes(parent: organization_program, name: "Core")
-    create(:clinical_provider, identity: identity, organization: organization)
-    create(:project_role_pi, identity: identity, protocol: @protocol)
-    create(:super_user, identity: identity, organization: organization_provider, billing_manager: true, allow_credit: true)
+    create(:clinical_provider, identity: @logged_in_identity, organization: organization)
+    create(:project_role_pi, identity: @logged_in_identity, protocol: @protocol)
+    create(:super_user, identity: @logged_in_identity, organization: organization_provider, billing_manager: true, allow_credit: true)
 
     @protocols_participant   = @protocol.protocols_participants.first
     @visit_group   = @protocols_participant.appointments.first.visit_group
@@ -81,17 +80,11 @@ feature 'Invoice Procedure', js: true do
 
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
 
-    first('a.list-group-item.appointment-link').click
-    bootstrap_select '[name="service_id"]', @service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
+    add_a_procedure(@service)
   end
 
   def and_i_am_adding_a_procedure
-    first('a.list-group-item.appointment-link').click
-    bootstrap_select '[name="service_id"]', @service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
+    add_a_procedure(@service)
   end
 
   def and_i_am_viewing_uncompleted_procedures
@@ -100,7 +93,7 @@ feature 'Invoice Procedure', js: true do
             appointment: appointment,
             service: @service,
             credited: true)
-    visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
+    given_i_am_viewing_a_visit
   end
 
   def and_i_am_viewing_completed_procedures
@@ -111,7 +104,7 @@ feature 'Invoice Procedure', js: true do
             service: @service,
             completed_date: DateTime.current.strftime('%m/%d/%Y'),
             credited: true)
-    visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
+    given_i_am_viewing_a_visit
   end
 
   def when_i_start_the_appointment

--- a/spec/features/appointments/appointment_calendar/grouped_services/identity_incompletes_all_services_spec.rb
+++ b/spec/features/appointments/appointment_calendar/grouped_services/identity_incompletes_all_services_spec.rb
@@ -23,9 +23,10 @@ require 'rails_helper'
 feature 'Identity incompletes all Services', js: true do
 
   before :each do
+    DatabaseCleaner[:active_record, model: Procedure].clean_with(:truncation)
     @protocol     = create(:protocol_imported_from_sparc)
     org           = @protocol.sub_service_request.organization
-                    create(:clinical_provider, identity: Identity.first, organization: org)
+                    create(:clinical_provider, identity: @logged_in_identity, organization: org)
     @protocols_participant  = @protocol.protocols_participants.first
     @appointment  = @protocols_participant.appointments.first
     @services     = @protocol.organization.inclusive_child_services(:per_participant)

--- a/spec/features/appointments/appointment_calendar/grouped_services/identity_invoices_a_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/grouped_services/identity_invoices_a_procedure_spec.rb
@@ -71,7 +71,7 @@ feature 'Invoice Procedure', js: true do
   def and_i_am_adding_a_procedure
     visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
 
-    find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
     
     bootstrap_select '[name="service_id"]', @service.name
@@ -88,7 +88,7 @@ feature 'Invoice Procedure', js: true do
             completed_date: DateTime.current.strftime('%m/%d/%Y'),
             invoiced: true)
     visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
-    find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
   end
 
@@ -100,7 +100,7 @@ feature 'Invoice Procedure', js: true do
 
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
 
-    find('a.list-group-item[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
     
     bootstrap_select '[name="service_id"]', service.name

--- a/spec/features/appointments/appointment_calendar/grouped_services/identity_removes_a_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/grouped_services/identity_removes_a_procedure_spec.rb
@@ -77,8 +77,6 @@ feature 'Identity removes a Procedure', js: true do
     find("tr.info.groupBy.expanded").click
     wait_for_ajax
 
-    procedure = Procedure.first
-
     first('a.delete-button').click
     wait_for_ajax
 

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_adds_core_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_adds_core_spec.rb
@@ -24,8 +24,8 @@ feature 'User adds a Procedure to an unstarted visit', js: true do
 
   before :each do
     @protocol     = create_and_assign_protocol_to_me
-    @protocols_participant  = ProtocolsParticipant.first
-    @appointment  = Appointment.first
+    @protocols_participant  = @protocol.protocols_participants.first
+    @appointment  = @protocols_participant.appointments.first
     @services     = @protocol.organization.inclusive_child_services(:per_participant)
   end
 
@@ -54,7 +54,6 @@ feature 'User adds a Procedure to an unstarted visit', js: true do
   end
 
   def when_i_add_2_procedures_to_same_group
-    sleep 2#Troubleshooting Travis Failure
     add_a_procedure @services.first, 2
   end
 

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_changes_procedure_performer_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_changes_procedure_performer_spec.rb
@@ -40,7 +40,7 @@ feature 'User changes performer of a procedure', js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
 
-    find('a[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
     
     bootstrap_select '[name="service_id"', service.name

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_changes_procedure_performer_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_changes_procedure_performer_spec.rb
@@ -43,10 +43,7 @@ feature 'User changes performer of a procedure', js: true do
     first('a.list-group-item.appointment-link').click
     wait_for_ajax
     
-    bootstrap_select '[name="service_id"', service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
-    wait_for_ajax
+    add_a_procedure(service)
 
     find('a.start-appointment').click
     wait_for_ajax
@@ -60,7 +57,7 @@ feature 'User changes performer of a procedure', js: true do
   end
 
   def when_i_view_the_notes
-    find('div#procedure1Notes').click
+    find("div#procedure#{@procedure.id}Notes").click
   end
 
   def then_i_should_see_a_note_indicating_that_the_performer_was_changed

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_completes_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_completes_procedure_spec.rb
@@ -70,10 +70,7 @@ feature 'User completes Procedure', js: true do
     first('a.list-group-item.appointment-link').click
     wait_for_ajax
     
-    bootstrap_select '[name="service_id"', service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
-    wait_for_ajax
+    add_a_procedure(service)
 
     visit_group.appointments.first.procedures.reload
     @procedure = visit_group.appointments.first.procedures.where(service_id: service.id).first
@@ -109,7 +106,7 @@ feature 'User completes Procedure', js: true do
   end
 
   def when_i_view_the_notes_list
-    find('div#procedure1Notes').click
+    find("div#procedure#{@procedure.id}Notes").click
   end
 
   def then_i_should_see_complete_notes count=1
@@ -121,6 +118,6 @@ feature 'User completes Procedure', js: true do
   end
 
   def then_i_should_see_a_helpful_message
-    expect(page).to have_css("div#procedure1StatusButtons[data-original-title=\"Click \'Start Visit\' and enter a start date to continue.\"]", visible: false)
+    expect(page).to have_css("div#procedure#{@procedure.id}StatusButtons[data-original-title=\"Click \'Start Visit\' and enter a start date to continue.\"]", visible: false)
   end
 end

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_completes_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_completes_procedure_spec.rb
@@ -67,7 +67,7 @@ feature 'User completes Procedure', js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
 
-    find('a[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
     
     bootstrap_select '[name="service_id"', service.name

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_creates_followup_note_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_creates_followup_note_spec.rb
@@ -90,10 +90,7 @@ feature 'Followup note', js: true do
     first('a.list-group-item.appointment-link').click
     wait_for_ajax
 
-    bootstrap_select '[name="service_id"', service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
-    wait_for_ajax
+    add_a_procedure(service)
 
     @procedure = visit_group.appointments.first.procedures.where(service_id: service.id).first
   end
@@ -110,7 +107,7 @@ feature 'Followup note', js: true do
   end
 
   def when_i_click_the_followup_button
-    find('td.followup div#followup1').click
+    find("td.followup div#followup#{@procedure.id}").click
   end
 
   def when_i_fill_out_and_submit_the_followup_form
@@ -122,7 +119,7 @@ feature 'Followup note', js: true do
   end
 
   def when_i_view_the_notes_list
-    find('div#procedure1Notes a.btn').click
+    find("div#procedure#{@procedure.id}Notes a.btn").click
   end
 
   def when_i_visit_the_tasks_index_page
@@ -131,7 +128,7 @@ feature 'Followup note', js: true do
   end
 
   def when_i_try_to_add_a_follow_up_note
-    find('td.followup div#followup1').click
+    find("td.followup div#followup#{@procedure.id}").click
     alert = page.driver.browser.switch_to.alert
     @alert_message = alert.text
     alert.accept
@@ -139,12 +136,11 @@ feature 'Followup note', js: true do
   end
 
   def then_i_should_see_the_followup_button
-    expect(page).to have_css('td.followup div#followup1')
+    expect(page).to have_css("td.followup div#followup#{@procedure.id}")
   end
 
   def then_i_should_see_a_text_field_with_the_followup_date
-    procedure = Procedure.first
-    expect(page).to have_css("input#followupDatePickerInput#{procedure.id}[value='#{Time.new(Time.now.year,Time.now.month,10).strftime("%m/%d/%Y")}']")
+    expect(page).to have_css("input#followupDatePickerInput#{@procedure.id}[value='#{Time.new(Time.now.year,Time.now.month,10).strftime("%m/%d/%Y")}']")
   end
 
   def then_i_should_see_the_note_i_created
@@ -156,7 +152,7 @@ feature 'Followup note', js: true do
   end
 
   def then_i_should_be_able_to_edit_the_followup_date
-    bootstrap_datepicker '#followupDatePickerInput1', day: '15'
+    bootstrap_datepicker "#followupDatePickerInput#{@procedure.id}", day: '15'
   end
 
   def then_i_should_see_the_date_change
@@ -164,6 +160,6 @@ feature 'Followup note', js: true do
   end
 
   def then_i_should_see_a_helpful_message
-    expect(page).to have_css("div#procedure1StatusButtons[data-original-title=\"Click \'Start Visit\' and enter a start date to continue.\"]", visible: false)
+    expect(page).to have_css("div#procedure#{@procedure.id}StatusButtons[data-original-title=\"Click \'Start Visit\' and enter a start date to continue.\"]", visible: false)
   end
 end

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_creates_followup_note_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_creates_followup_note_spec.rb
@@ -87,7 +87,7 @@ feature 'Followup note', js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
 
-    find('a[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
 
     bootstrap_select '[name="service_id"', service.name

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_creates_procedure_note_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_creates_procedure_note_spec.rb
@@ -50,14 +50,13 @@ feature 'User creates a procedure note', js: true do
     find('a.start-appointment').click
     wait_for_ajax
 
-    bootstrap_select '[name="service_id"', service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
-    wait_for_ajax
+    add_a_procedure(service)
+
+    @procedure = visit_group.appointments.first.procedures.where(service_id: service.id).first
   end
 
   def when_i_set_a_followup
-    find('div#followup1 a.btn').click
+    find("div#followup#{@procedure.id} a.btn").click
 
     bootstrap_select '#task_assignee_id', @assignee.full_name
     bootstrap_datepicker '#task_due_at', day: '10'
@@ -67,7 +66,7 @@ feature 'User creates a procedure note', js: true do
   end
 
   def when_i_view_the_notes_list
-    find('div#procedure1Notes a.btn').click
+    find("div#procedure#{@procedure.id}Notes a.btn").click
   end
 
   def then_i_should_see_a_notice_that_there_are_no_notes

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_incompletes_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_incompletes_procedure_spec.rb
@@ -128,7 +128,7 @@ feature 'Incomplete Procedure', js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
 
-    find('a[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
     
     bootstrap_select '[name="service_id"', service.name

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_incompletes_procedure_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_incompletes_procedure_spec.rb
@@ -81,29 +81,15 @@ feature 'Incomplete Procedure', js: true do
       end
     end
 
-    context 'and marks a procedure as incomplete and then changes their mind, clicking incomplete again' do
-      scenario 'and sees that there is a status reset note' do
+    context 'and marks a procedure as incomplete and then changes their mind, clicking unstarted' do
+      scenario 'and sees the status reset note, and status and performed by have been reset' do
         given_i_am_viewing_an_appointment_with_a_procedure
         when_i_begin_the_appointment
         when_i_incomplete_the_procedure
-        when_i_click_the_incomplete_button
+        when_i_unstart_the_procedure
         when_i_view_the_notes_list
         then_i_should_see_one_status_incomplete_note
-      end
-
-      scenario 'and sees that the status has been reset' do
-        given_i_am_viewing_an_appointment_with_a_procedure
-        when_i_begin_the_appointment
-        when_i_incomplete_the_procedure
-        when_i_click_the_incomplete_button
         then_i_should_see_that_the_procedure_status_has_been_reset
-      end
-
-      scenario 'and sees that the performed by dropdown has been reset' do
-        given_i_am_viewing_an_appointment_with_a_procedure
-        when_i_begin_the_appointment
-        when_i_incomplete_the_procedure
-        when_i_click_the_incomplete_button
         then_i_should_see_that_the_procedure_performed_by_has_been_reset
       end
     end
@@ -131,16 +117,15 @@ feature 'Incomplete Procedure', js: true do
     first('a.list-group-item.appointment-link').click
     wait_for_ajax
     
-    bootstrap_select '[name="service_id"', service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
-    wait_for_ajax
+    add_a_procedure(service)
+
+    @procedure = visit_group.appointments.first.procedures.where(service_id: service.id).first
   end
 
   def given_i_am_viewing_a_procedure_marked_as_complete
     given_i_am_viewing_an_appointment_with_a_procedure
     when_i_begin_the_appointment
-    find('div#procedure1StatusButtons button.complete-btn').click
+    find("div#procedure#{@procedure.id}StatusButtons button.complete-btn").click
     wait_for_ajax
   end
 
@@ -150,7 +135,7 @@ feature 'Incomplete Procedure', js: true do
   end
 
   def when_i_complete_the_procedure
-    find('div#procedure1StatusButtons button.complete-btn').click
+    find("div#procedure#{@procedure.id}StatusButtons button.complete-btn").click
     wait_for_ajax
   end
 
@@ -160,8 +145,13 @@ feature 'Incomplete Procedure', js: true do
     when_i_save_the_incomplete
   end
 
+  def when_i_unstart_the_procedure
+    find("div#procedure#{@procedure.id}StatusButtons button.unstarted-btn").click
+    wait_for_ajax
+  end
+
   def when_i_click_the_incomplete_button
-    find('div#procedure1StatusButtons button.incomplete-btn').click
+    find("div#procedure#{@procedure.id}StatusButtons button.incomplete-btn").click
     wait_for_ajax
   end
 
@@ -174,21 +164,21 @@ feature 'Incomplete Procedure', js: true do
   def when_i_save_the_incomplete
     sleep 1
     find('input[type="submit"]').click
+    wait_for_ajax
   end
 
   def when_i_cancel_the_incomplete
+    sleep 1
     find("button.btn-secondary").click
+    wait_for_ajax
   end
 
   def then_i_should_see_that_i_am_the_procedure_performer
-    procedure  = Procedure.first
-    identity   = Identity.first
-
-    expect(page).to have_css("td.performer button.btn[title='#{identity.first_name} #{identity.last_name}']")
+    expect(page).to have_css("td.performer button.btn[title='#{@logged_in_identity.first_name} #{@logged_in_identity.last_name}']")
   end
 
   def when_i_view_the_notes_list
-    find('div#procedure1Notes a.btn').click
+    find("div#procedure#{@procedure.id}Notes a.btn").click
   end
 
   def when_i_close_the_notes_list
@@ -196,7 +186,7 @@ feature 'Incomplete Procedure', js: true do
   end
 
   def when_i_try_to_incomplete_the_procedure
-    find('div#procedure1StatusButtons button.incomplete-btn').click
+    find("div#procedure#{@procedure.id}StatusButtons button.incomplete-btn").click
     wait_for_ajax
   end
 
@@ -227,17 +217,14 @@ feature 'Incomplete Procedure', js: true do
   end
 
   def then_i_should_see_that_the_procedure_status_has_been_reset
-    expect(page).to have_css("td.completed-date input#procedure_completed_date[disabled]")
+    expect(page).to have_css("div#procedure#{@procedure.id}StatusButtons .unstarted-btn.active")
   end
 
   def then_i_should_see_that_the_procedure_performed_by_has_been_reset
-    procedure  = Procedure.first
-    identity   = Identity.first
-
-    expect(page).to have_css("td.performer button.btn[title='#{identity.first_name} #{identity.last_name}']")
+    expect(page).to_not have_css("td.performer button.btn[title='#{@logged_in_identity.first_name} #{@logged_in_identity.last_name}']")
   end
 
   def then_i_should_see_a_helpful_message
-    expect(page).to have_css("div#procedure1StatusButtons[data-original-title=\"Click \'Start Visit\' and enter a start date to continue.\"]", visible: false)
+    expect(page).to have_css("div#procedure#{@procedure.id}StatusButtons[data-original-title=\"Click \'Start Visit\' and enter a start date to continue.\"]", visible: false)
   end
 end

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_messes_with_procedure_date_completed_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_messes_with_procedure_date_completed_spec.rb
@@ -102,7 +102,7 @@ feature 'User messes with a procedures date completed', js: true do
     visit_group = @protocols_participant.appointments.first.visit_group
     service     = @protocol.organization.inclusive_child_services(:per_participant).first
 
-    find('a[data-appointment-id="1"]').click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
     bootstrap_select '[name="service_id"', service.name
     fill_in 'service_quantity', with: 1

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_messes_with_procedure_date_completed_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_messes_with_procedure_date_completed_spec.rb
@@ -85,14 +85,15 @@ feature 'User messes with a procedures date completed', js: true do
   end
 
   def when_i_complete_the_procedure
-    find('div#procedure1StatusButtons button.complete-btn').click
+    find("div#procedure#{@procedure.id}StatusButtons button.complete-btn").click
     wait_for_ajax
   end
 
   def when_i_incomplete_the_procedure
     reason = Procedure::NOTABLE_REASONS.first
 
-    find('div#procedure1StatusButtons button.incomplete-btn').click
+    find("div#procedure#{@procedure.id}StatusButtons button.incomplete-btn").click
+    wait_for_ajax
     bootstrap_select '#procedure_notes_attributes_0_reason', reason
     fill_in 'Comment', with: 'Test comment'
     find('input.btn[type="submit"]').click
@@ -104,14 +105,14 @@ feature 'User messes with a procedures date completed', js: true do
 
     first('a.list-group-item.appointment-link').click
     wait_for_ajax
-    bootstrap_select '[name="service_id"', service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
-    wait_for_ajax
+    
+    add_a_procedure(service)
+
+    @procedure = visit_group.appointments.first.procedures.where(service_id: service.id).first
   end
 
   def when_i_edit_the_completed_date
-    @complete_procedure    = Procedure.complete.first
+    @complete_procedure    = Procedure.complete.last
     existing_day           = @complete_procedure.completed_date.strftime("%-d").to_i
     @new_day               = pick_new_date(existing_day)
     @edited_completed_date = Time.now.change(day: @new_day)

--- a/spec/features/appointments/appointment_calendar/procedure_management/identity_sets_procedure_performer_spec.rb
+++ b/spec/features/appointments/appointment_calendar/procedure_management/identity_sets_procedure_performer_spec.rb
@@ -55,13 +55,12 @@ feature 'User sets Procedure performer', js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
 
-    find("#appointmentsList a[data-appointment-id='#{visit_group.id}']").click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
 
-    bootstrap_select '[name="service_id"', service.name
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
-    wait_for_ajax
+    add_a_procedure(service)
+
+    @procedure = visit_group.appointments.first.procedures.where(service_id: service.id).first
   end
 
   def given_i_have_completed_a_procedure
@@ -82,12 +81,12 @@ feature 'User sets Procedure performer', js: true do
   end
 
   def when_i_uncomplete_the_procedure
-    find('button.incomplete-btn').click
+    find('button.unstarted-btn').click
     wait_for_ajax
   end
 
   def when_i_un_incomplete_the_procedure
-    find('button.incomplete-btn').click
+    find('button.unstarted-btn').click
     wait_for_ajax
   end
 
@@ -108,12 +107,10 @@ feature 'User sets Procedure performer', js: true do
   end
 
   def then_i_should_see_that_i_am_the_procedure_performer
-    @identity   = Identity.first
-    expect(page).to have_css("#core1ProceduresGroupedView td.performer div.filter-option", text: @identity.full_name)
+    expect(page).to have_css("#core#{@procedure.sparc_core_id}ProceduresGroupedView td.performer div.filter-option", text: @logged_in_identity.full_name)
   end
 
   def then_i_should_see_that_the_performer_has_not_been_set
-    @identity   = Identity.first
-    expect(page).to have_css("#core1ProceduresGroupedView td.performer div.filter-option", text: @identity.full_name)
+    expect(page).to_not have_css("#core#{@procedure.sparc_core_id}ProceduresGroupedView td.performer div.filter-option", text: @logged_in_identity.full_name)
   end
 end

--- a/spec/features/appointments/appointment_statuses/indicate_status_spec.rb
+++ b/spec/features/appointments/appointment_statuses/indicate_status_spec.rb
@@ -39,7 +39,7 @@ feature "Indicating a Status", js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
 
-    find("#appointmentsList a[data-appointment-id='#{visit_group.id}']").click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
   end
 

--- a/spec/features/appointments/appointment_statuses/removing_a_status_spec.rb
+++ b/spec/features/appointments/appointment_statuses/removing_a_status_spec.rb
@@ -39,14 +39,14 @@ feature 'Removing a Status', js: true do
     visit calendar_protocol_participant_path(id: protocols_participant.id, protocol_id: protocol)
     wait_for_ajax
 
-    find("#appointmentsList a[data-appointment-id='#{visit_group.id}']").click
+    first('a.list-group-item.appointment-link').click
     wait_for_ajax
   end
 
   def when_i_deselect_an_appointment_status
     # For fun of course
     bootstrap_select '#statuses', "Skipped Visit"
-    find('body').click()
+    find('body').native.send_keys(:escape)
     bootstrap_select '#statuses', "Skipped Visit"
     wait_for_ajax
   end

--- a/spec/features/appointments/identity_changes_participant_arm_spec.rb
+++ b/spec/features/appointments/identity_changes_participant_arm_spec.rb
@@ -51,16 +51,12 @@ feature "Change Participant Arm", js: :true do
     @service.update_attributes(name: 'Test Service')
     @original_appointment.update_attributes(name: "First Arm Appointment")
 
-    visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
-    wait_for_ajax
+    given_i_am_viewing_a_visit
 
     find('a.start-appointment').click
     wait_for_ajax
 
-    bootstrap_select '#add_procedure_dropdown', 'Test Service'
-    fill_in 'service_quantity', with: 1
-    find('button#addService').click
-    wait_for_ajax
+    add_a_procedure(@service)
   end
 
   def and_i_complete_a_procedure
@@ -80,8 +76,7 @@ feature "Change Participant Arm", js: :true do
   end
 
   def and_i_visit_the_calendar_again
-    visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
-    wait_for_ajax
+    given_i_am_viewing_a_visit
   end
 
   def i_should_see_new_and_old_appointments

--- a/spec/features/appointments/identity_creates_custom_appointment_spec.rb
+++ b/spec/features/appointments/identity_creates_custom_appointment_spec.rb
@@ -63,7 +63,7 @@ feature 'Custom appointment', js: true do
 
     case has_arm
     when :with_arm
-      @protocols_participant.update_attribute(:arm, Arm.first)
+      @protocols_participant.update_attribute(:arm, Arm.last)
     when :without_arm
       @protocols_participant.update_attribute(:arm, nil)
     end

--- a/spec/features/participants/identity_views_participant_spec.rb
+++ b/spec/features/participants/identity_views_participant_spec.rb
@@ -61,9 +61,7 @@ feature 'User views Participant', js: true do
   end
 
   def when_i_view_a_participants_calendar
-    visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
-    wait_for_ajax
-    wait_for_ajax
+    given_i_am_viewing_a_visit
   end
 
   def then_i_should_be_redirected_to_the_home_page
@@ -72,12 +70,12 @@ feature 'User views Participant', js: true do
 
   def then_i_should_see_the_participant_calendar
     expect(page).to have_css('#participantDetailsTable')
+    expect(page).to have_css('#appointmentsList')
     expect(page).to have_content(@protocols_participant.participant.full_name)
     expect(page).to have_content(@protocols_participant.participant.mrn) unless @protocols_participant.participant.mrn.blank?
     expect(page).to have_content(@protocols_participant.external_id) unless @protocols_participant.external_id.blank?
     expect(page).to have_content(@protocols_participant.arm.name) unless @protocols_participant.arm.blank?
     expect(page).to have_content(@protocols_participant.status)
-    expect(page).to have_content(@protocol.id)
   end
 
   def then_i_should_see_an_ordered_list_of_visits

--- a/spec/features/participants/identity_views_participant_spec.rb
+++ b/spec/features/participants/identity_views_participant_spec.rb
@@ -24,7 +24,7 @@ feature 'User views Participant', js: true do
 
   scenario 'and does not have access' do
     given_i_do_not_have_access_to_a_protocol
-    when_i_view_a_participants_calendar
+    when_i_try_to_view_a_participants_calendar
     then_i_should_be_redirected_to_the_home_page
   end
 
@@ -62,6 +62,11 @@ feature 'User views Participant', js: true do
 
   def when_i_view_a_participants_calendar
     given_i_am_viewing_a_visit
+  end
+
+  def when_i_try_to_view_a_participants_calendar
+    visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
+    wait_for_ajax
   end
 
   def then_i_should_be_redirected_to_the_home_page

--- a/spec/features/participants/participant_tracker/identity_changes_protocols_participant_status_spec.rb
+++ b/spec/features/participants/participant_tracker/identity_changes_protocols_participant_status_spec.rb
@@ -36,7 +36,7 @@ feature 'User changes the status of a participant on the participant tracker', j
 
   def given_i_am_viewing_the_participant_tracker
     @protocol    = create_and_assign_protocol_to_me
-    @protocols_participant = @protocol.protocols_participants.first
+    @protocols_participant = @protocol.protocols_participants.last
 
     visit protocol_path @protocol.id
     wait_for_ajax

--- a/spec/features/participants/participant_tracker/identity_creates_participant_notes_spec.rb
+++ b/spec/features/participants/participant_tracker/identity_creates_participant_notes_spec.rb
@@ -50,7 +50,7 @@ feature 'User views the participant tracker page', js: true do
 
   def given_i_am_viewing_the_participant_tracker
     @protocol = create_and_assign_protocol_to_me
-    @protocols_participant = @protocol.protocols_participants.first
+    @protocols_participant = @protocol.protocols_participants.last
     @original_arm = @protocols_participant.arm
 
     visit protocol_path @protocol

--- a/spec/features/participants/participant_tracker/identity_creates_participant_notes_spec.rb
+++ b/spec/features/participants/participant_tracker/identity_creates_participant_notes_spec.rb
@@ -61,7 +61,7 @@ feature 'User views the participant tracker page', js: true do
   end
 
   def when_i_click_on_the_notes_button
-    find("#participant#{@protocols_participant.id}Notes a").click
+    find("#participant#{@protocols_participant.participant_id}Notes a").click
     wait_for_ajax
 
     sleep 2#Travis failure

--- a/spec/features/participants/participant_tracker/identity_deletes_protocols_participant_spec.rb
+++ b/spec/features/participants/participant_tracker/identity_deletes_protocols_participant_spec.rb
@@ -37,7 +37,7 @@ feature 'User deletes Participant', js: true do
   end
 
   def and_the_participant_is_not_deletable
-    protocols_participant = ProtocolsParticipant.first
+    protocols_participant = ProtocolsParticipant.last
     create(:procedure_complete, appointment: protocols_participant.appointments.first, arm: @protocol.arms.first)
   end
 

--- a/spec/features/participants/participant_tracker/identity_views_participant_tracker_spec.rb
+++ b/spec/features/participants/participant_tracker/identity_views_participant_tracker_spec.rb
@@ -28,6 +28,8 @@ feature 'User views Participant Tracker', js: true do
   end
 
   def given_i_am_viewing_the_participant_tracker
+    DatabaseCleaner[:active_record, model: Participant].clean_with(:truncation)
+    DatabaseCleaner[:active_record, model: ProtocolsParticipant].clean_with(:truncation)
     protocol = create_and_assign_protocol_to_me
 
     visit protocol_path(protocol.id)

--- a/spec/features/participants/patient_registry/identity_creates_participant_spec.rb
+++ b/spec/features/participants/patient_registry/identity_creates_participant_spec.rb
@@ -66,7 +66,8 @@ feature 'User creates Participant', js: true do
   end
 
   def given_i_am_viewing_the_patient_registry
-    create(:patient_registrar, identity: Identity.first, organization: create(:organization))
+    DatabaseCleaner[:active_record, model: Participant].clean_with(:truncation)
+    create(:patient_registrar, identity: @logged_in_identity, organization: create(:organization))
     visit participants_path
     wait_for_ajax
     wait_for_ajax

--- a/spec/features/participants/patient_registry/identity_deletes_participant_spec.rb
+++ b/spec/features/participants/patient_registry/identity_deletes_participant_spec.rb
@@ -42,9 +42,9 @@ feature 'User deletes Participant', js: true do
   end
 
   def given_i_have_a_participant
+    DatabaseCleaner[:active_record, model: Participant].clean_with(:truncation)
     @protocol = create_and_assign_protocol_to_me
-    @participants = Participant.all.order(Arel.sql("participants.last_name asc"))
-    @participant = @participants.first
+    @participant = Participant.last
   end
 
   def and_the_participant_has_procedure_data

--- a/spec/features/protocols/identity_views_protocols_spec.rb
+++ b/spec/features/protocols/identity_views_protocols_spec.rb
@@ -50,10 +50,12 @@ feature 'Identity views protocols', js: true do
   end
 
   def given_i_am_a_fulfillment_provider_for_a_protocol
-    create_and_assign_protocol_to_me
+    DatabaseCleaner[:active_record, model: Protocol].clean_with(:truncation)
+    @protocol = create_and_assign_protocol_to_me
   end
 
   def given_i_am_not_a_fulfillment_provider_for_a_protocol
+    DatabaseCleaner[:active_record, model: Protocol].clean_with(:truncation)
     organization            = create(:organization)
     sub_service_request     = create(:sub_service_request, organization: organization)
     @unauthorized_protocol  = create(:protocol, sub_service_request: sub_service_request)
@@ -69,7 +71,7 @@ feature 'Identity views protocols', js: true do
   end
 
   def and_a_change_is_made_to_the_protocol_by_another_identity
-    Protocol.first.sparc_protocol.update_attribute :short_title, 'Test 123'
+    @protocol.sparc_protocol.update_attribute :short_title, 'Test 123'
     refresh_bootstrap_table('table#protocols')
   end
 

--- a/spec/features/reports/identity_creates_protocol_based_document_spec.rb
+++ b/spec/features/reports/identity_creates_protocol_based_document_spec.rb
@@ -25,6 +25,7 @@ require 'rails_helper'
 feature 'Identity creates a protocol-based Document', js: true, enqueue: false do
 
   before :each do
+    DatabaseCleaner[:active_record, model: Document].clean_with(:truncation)
     given_i_am_viewing_the_reports_tab
   end
 

--- a/spec/features/reports/identity_deletes_document_spec.rb
+++ b/spec/features/reports/identity_deletes_document_spec.rb
@@ -109,6 +109,7 @@ feature 'Identity deletes a document', js: true, enqueue: false do
   end
 
   def when_i_click_the_delete_icon
+    @count_before_delete = @logged_in_identity.unaccessed_documents_count
     first("a.remove-document").click
     accept_confirm
     wait_for_ajax
@@ -123,7 +124,7 @@ feature 'Identity deletes a document', js: true, enqueue: false do
   end
 
   def then_i_should_see_the_identity_docs_counter_was_decremented
-    expect(page).to have_css(".identity_report_notifications", text: 1)
+    expect(page).to have_css(".identity_report_notifications", text: (@count_before_delete - 1))
   end
 
   def then_i_should_see_the_protocol_docs_counter_was_decremented

--- a/spec/features/reports/identity_downloads_document_from_documents_page_spec.rb
+++ b/spec/features/reports/identity_downloads_document_from_documents_page_spec.rb
@@ -22,6 +22,10 @@ require 'rails_helper'
 
 feature 'Identity downloads a document from the documents page', js: true, enqueue: false do
 
+  before :each do
+    DatabaseCleaner[:active_record, model: Document].clean_with(:truncation)
+  end
+
   scenario 'and sees the viewed_at date has been updated' do
     given_i_am_viewing_the_all_reports_page_with_documents
     when_i_download_the_report
@@ -40,7 +44,7 @@ feature 'Identity downloads a document from the documents page', js: true, enque
     scenario 'and sees the documents counter decrement' do
       given_i_am_viewing_the_all_reports_page_with_documents(2)
       when_i_download_the_report
-      then_i_should_see_the_documents_counter_decrement_to(1)
+      then_i_should_see_the_documents_counter_decrement_to(@count_before_download - 1)
     end
   end
 
@@ -48,7 +52,7 @@ feature 'Identity downloads a document from the documents page', js: true, enque
     @protocol = create_and_assign_protocol_to_me
 
     count.times do
-      create(:document_of_identity_report, documentable_id: Identity.first.id)
+      create(:document_of_identity_report, documentable_id: @logged_in_identity.id)
     end
 
     visit documents_path
@@ -56,6 +60,7 @@ feature 'Identity downloads a document from the documents page', js: true, enque
   end
 
   def when_i_download_the_report
+    @count_before_download = @logged_in_identity.unaccessed_documents_count
     first("a.attached_file").click
     wait_for_ajax
   end

--- a/spec/features/reports/identity_downloads_document_from_reports_tab_spec.rb
+++ b/spec/features/reports/identity_downloads_document_from_reports_tab_spec.rb
@@ -22,6 +22,10 @@ require 'rails_helper'
 
 feature 'Identity downloads a document from the reports tab', js: true, enqueue: false do
 
+  before :each do
+    DatabaseCleaner[:active_record, model: Document].clean_with(:truncation)
+  end
+
   scenario 'and sees the viewed_at date has been updated' do
     given_i_am_viewing_the_reports_tab_with_documents
     when_i_download_the_report

--- a/spec/features/reports/identity_edits_document_title_spec.rb
+++ b/spec/features/reports/identity_edits_document_title_spec.rb
@@ -22,6 +22,10 @@ require 'rails_helper'
 
 feature 'Identity edits document title', js: true, enqueue: false do
 
+  before :each do
+    DatabaseCleaner[:active_record, model: Document].clean_with(:truncation)
+  end
+
   context "from the All Reports page" do
     context "when creating a report" do
       scenario "and sees the custom title" do

--- a/spec/features/study_schedule/management/identity_edits_arms_spec.rb
+++ b/spec/features/study_schedule/management/identity_edits_arms_spec.rb
@@ -148,6 +148,7 @@ feature 'Identity edits arms on protocol study schedule', js: true do
 
   def when_i_click_the_add_submit_button
     wait_for_ajax
+    sleep 5 #Travis Failure
     find('input[type="submit"]').click
     wait_for_ajax
   end
@@ -159,7 +160,7 @@ feature 'Identity edits arms on protocol study schedule', js: true do
   end
 
   def when_i_click_the_save_submit_button
-    sleep 2
+    sleep 5
     find('input[type="submit"]').click
     wait_for_ajax
   end

--- a/spec/features/study_schedule/management/identity_edits_visit_groups_spec.rb
+++ b/spec/features/study_schedule/management/identity_edits_visit_groups_spec.rb
@@ -170,6 +170,7 @@ feature 'Identity edits visit groups for a particular protocol', js: true do
   end
 
   def when_i_click_the_remove_submit_button
+    sleep 5
     @visit_group_id_to_be_deleted = @visit_groups.first.id
     find('#removeVisitGroupButton').click
     find('button.swal2-confirm').click

--- a/spec/features/study_schedule/study_schedule_spec.rb
+++ b/spec/features/study_schedule/study_schedule_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe 'Study Schedule', js: true do
   end
 
   def when_i_click_a_check_all_column_box
-    find("button[data-visit-group-id='#{@visit.id}']").click
+    find("button[data-visit-group-id='#{@visit_group.id}']").click
     accept_confirm
     wait_for_ajax
   end

--- a/spec/features/study_schedule/study_schedule_spec.rb
+++ b/spec/features/study_schedule/study_schedule_spec.rb
@@ -250,7 +250,9 @@ RSpec.describe 'Study Schedule', js: true do
 
   def when_i_click_a_check_all_row_box
     find("#line_item_#{@line_item.id} .check-row").click
+    sleep 2
     accept_confirm
+    sleep 2
     wait_for_ajax
   end
 
@@ -262,7 +264,9 @@ RSpec.describe 'Study Schedule', js: true do
 
   def when_i_click_a_check_all_column_box
     find("button[data-visit-group-id='#{@visit_group.id}']").click
+    sleep 2
     accept_confirm
+    sleep 2
     wait_for_ajax
   end
 

--- a/spec/features/study_schedule/study_schedule_spec.rb
+++ b/spec/features/study_schedule/study_schedule_spec.rb
@@ -256,6 +256,7 @@ RSpec.describe 'Study Schedule', js: true do
 
   def when_i_click_an_uncheck_all_row_box
     when_i_click_a_check_all_row_box #Check
+    sleep 1
     when_i_click_a_check_all_row_box #Uncheck
   end
 

--- a/spec/features/tasks/complete_task_spec.rb
+++ b/spec/features/tasks/complete_task_spec.rb
@@ -29,7 +29,7 @@ feature "Completing a Task", js: true do
   end
 
   def given_i_have_an_assigned_task
-    assignee = Identity.first
+    assignee = @logged_in_identity
     assignor = create(:identity)
     create_list(:task, 2, identity: assignor, assignee: assignee)
 
@@ -38,10 +38,11 @@ feature "Completing a Task", js: true do
   end
 
   def when_i_mark_the_task_as_complete
+    @count_before_marked = Task.where(assignee: @logged_in_identity).count
     first('input.complete').click
   end
 
   def then_i_should_not_see_the_task
-    expect(page).to have_css("table.tasks tbody tr", count: 1)
+    expect(page).to have_css("table.tasks tbody tr", count: (@count_before_marked - 1))
   end
 end

--- a/spec/features/tasks/task_notifications_spec.rb
+++ b/spec/features/tasks/task_notifications_spec.rb
@@ -43,13 +43,13 @@ feature "Task notifications", js: true do
   end
 
   def given_i_have_no_tasks
-    # Devise#sign_in
+    DatabaseCleaner[:active_record, model: Task].clean_with(:truncation)
   end
 
   def given_i_have_one_task
     assignee = Identity.first
     assignor = create(:identity)
-
+    DatabaseCleaner[:active_record, model: Task].clean_with(:truncation)
     create(:task, identity: assignor, assignee: assignee)
   end
 
@@ -59,7 +59,7 @@ feature "Task notifications", js: true do
   end
 
   def when_i_click_on_the_task_notification
-    find("input[type='checkbox']").set(true)
+    first("input[type='checkbox']").set(true)
   end
 
   def then_i_should_be_on_the_tasks_page

--- a/spec/features/tasks/view_task_spec.rb
+++ b/spec/features/tasks/view_task_spec.rb
@@ -22,14 +22,12 @@ require "rails_helper"
 
 feature "Identity views Task", js: true do
   before :each do
-    identity = Identity.first
-    create(:protocol_imported_from_sparc)
+    @assignee = Identity.first
+    protocol = create(:protocol_imported_from_sparc)
     @core = Organization.where(type: "Core").first
     @program = create(:organization_program)
     @core.update_attributes(parent_id: @program.id)
-    ClinicalProvider.create(organization: Organization.first, identity: identity)
-    clinical_providers = ClinicalProvider.where(organization_id: identity.protocols.map{|p| p.sub_service_request.organization_id })
-    @assignee = clinical_providers.first.identity
+    ClinicalProvider.create(organization: protocol.sub_service_request.organization, identity: @assignee)
   end
 
   scenario "Identity views a Task that have assigned to themselves" do
@@ -63,6 +61,8 @@ feature "Identity views Task", js: true do
   end
 
   def given_i_have_been_assigned_a_procedure_task
+    DatabaseCleaner[:active_record, model: Task].clean_with(:truncation)
+    
     create(:protocol_imported_from_sparc)
     identity        = Identity.first
     appointment = Appointment.first
@@ -74,7 +74,7 @@ feature "Identity views Task", js: true do
 
   def when_i_view_the_procedure_task_assigned_to_myself
     given_i_am_on_the_tasks_page
-    find("table.tasks tbody tr:first-child").click
+    first("table.tasks tbody tr:first-child td").click
   end
 
   def then_i_should_see_the_identity_task_details

--- a/spec/features/tasks/view_tasks_spec.rb
+++ b/spec/features/tasks/view_tasks_spec.rb
@@ -35,6 +35,7 @@ feature "View Tasks", js: true do
   end
 
   scenario "Identity views only their Tasks" do
+    given_i_have_no_tasks
     given_other_users_have_assigned_tasks
     when_i_visit_the_tasks_page
     then_i_should_only_see_tasks_assigned_to_me
@@ -72,6 +73,7 @@ feature "View Tasks", js: true do
   end
 
   def given_other_tasks_have_been_assigned_to_a_different_identity
+    DatabaseCleaner[:active_record, model: Task].clean_with(:truncation)
     given_i_have_incomplete_tasks
 
     other_user = create(:identity)
@@ -90,7 +92,7 @@ feature "View Tasks", js: true do
   end
 
   def given_i_have_no_tasks
-    # Devise#sign_in
+    DatabaseCleaner[:active_record, model: Task].clean_with(:truncation)
   end
 
   def when_i_view_complete_tasks
@@ -125,6 +127,6 @@ feature "View Tasks", js: true do
   end
 
   def then_i_should_see_all_tasks
-    expect(page).to have_css("table.tasks tbody tr", count: 4)
+    expect(page).to have_css("table.tasks tbody tr", count: Task.count)
   end
 end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -158,18 +158,20 @@ RSpec.describe Identity, type: :model do
     context "IdentityCounter exists" do
 
       it "should not create a new IdentityCounter" do
+        count_before_test = IdentityCounter.count
         identity = create(:identity_with_counter)
         expect(identity.identity_counter).to be
-        expect(IdentityCounter.count).to eq(1)
+        expect(IdentityCounter.count).to eq(count_before_test + 1)
       end
     end
 
     context "IdentityCounter does not exist" do
 
       it "should create an IdentityCounter if it does not exist" do
+        count_before_test = IdentityCounter.count
         identity = create(:identity)
         expect(identity.identity_counter).to be
-        expect(IdentityCounter.count).to eq(1)
+        expect(IdentityCounter.count).to eq(count_before_test + 1)
       end
     end
   end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Notification, type: :model do
 
     describe '.duplicate_not_present?' do
 
+      before :each do
+        DatabaseCleaner[:active_record, model: Notification].clean_with(:truncation)
+      end
+
       context 'duplicate present' do
 
         it 'should not allow the object to be persisted' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -80,11 +80,12 @@ RSpec.describe Procedure, type: :model do
       end
 
       it 'should destroy the record if the status is unstarted' do
+        count_before_test = Procedure.count
         procedure = create(:procedure)
 
         procedure.destroy
 
-        expect(Procedure.count).to eq(0)
+        expect(Procedure.count).to eq(count_before_test)
       end
 
       it 'should not destroy the record if the status is not unstarted' do

--- a/spec/models/visit_group_spec.rb
+++ b/spec/models/visit_group_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe VisitGroup, type: :model do
 
       context "insertion results in out-of-order days" do
         it "should be invalid" do
-          arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm1")
+          arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm2")
           create(:visit_group, position: 1, day: 1, arm: arm)
           create(:visit_group, position: 2, day: 8, arm: arm)
 
@@ -76,7 +76,7 @@ RSpec.describe VisitGroup, type: :model do
       context "changing position towards the beginning" do
         context "results in in-order days" do
           it "should be valid" do
-            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm1")
+            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm3")
             create(:visit_group, position: 1, day: 1, arm: arm)
             create(:visit_group, position: 2, day: 8, arm: arm)
             vg = build(:visit_group, position: 3, day: 4, arm: arm)
@@ -90,7 +90,7 @@ RSpec.describe VisitGroup, type: :model do
 
         context "result in out-of-order days" do
           it "should be invalid" do
-            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm1")
+            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm4")
             create(:visit_group, position: 1, day: 1, arm: arm)
             create(:visit_group, position: 2, day: 8, arm: arm)
             vg = create(:visit_group, position: 3, day: 16, arm: arm)
@@ -105,7 +105,7 @@ RSpec.describe VisitGroup, type: :model do
       context "changing position towards the end" do
         context "results in in-order days" do
           it "should be valid" do
-            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm1")
+            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm5")
             vg = create(:visit_group, position: 1, day: 4, arm: arm)
             build(:visit_group, position: 2, day: 1, arm: arm).save(validate: false)
             build(:visit_group, position: 3, day: 8, arm: arm)
@@ -119,7 +119,7 @@ RSpec.describe VisitGroup, type: :model do
 
         context "result in out-of-order days" do
           it "should be invalid" do
-            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm1")
+            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm6")
             vg = create(:visit_group, position: 1, day: 1, arm: arm)
             create(:visit_group, position: 2, day: 8, arm: arm)
             create(:visit_group, position: 3, day: 16, arm: arm)
@@ -134,7 +134,7 @@ RSpec.describe VisitGroup, type: :model do
       context "adding visit as last" do
         context "result in out-of-order days" do
           it "should be invalid" do
-            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm1")
+            arm = Arm.create(subject_count: 1, visit_count: 1, name: "Arm7")
             create(:visit_group, position: 1, day: 1, arm: arm)
             create(:visit_group, position: 2, day: 8, arm: arm)
             vg = build(:visit_group, position: nil, day: 7, arm: arm)
@@ -166,6 +166,7 @@ RSpec.describe VisitGroup, type: :model do
     describe 'default_scope' do
 
       it 'should be scoped to position' do
+        DatabaseCleaner[:active_record, model: VisitGroup].clean_with(:truncation)
         groups = []
         # create them with positions 3,2,1
         (3..1).each do |p|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,8 +45,6 @@ require 'vcr'
 #
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
-Rails.application.eager_load! # this helps database_cleaner get to the shards
-
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,8 @@ require 'vcr'
 #
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
+Rails.application.eager_load! # this helps database_cleaner get to the shards
+
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,19 +45,6 @@ require 'rspec/retry'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |file| require file }
 
-Capybara.register_driver :webkit do |app|
-  driver = Capybara::Webkit::Driver.new(app, { set_skip_image_loading: true })
-  driver
-end
-
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    # Choose a test framework:
-    with.test_framework :rspec
-    with.library :rails
-  end
-end
-
 SimpleCov.start do
   add_group "Models", "app/models"
   add_group "Controllers", "app/controllers"
@@ -95,8 +82,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  config.backtrace_exclusion_patterns << /\/gems\//
-
   config.default_sleep_interval = 2
   config.verbose_retry = true
   config.default_retry_count = 4
@@ -107,7 +92,7 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
@@ -141,12 +126,27 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random
+  # config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
+
+  config.backtrace_exclusion_patterns << /gems/
+
+end
+
+Capybara.register_driver :webkit do |app|
+  driver = Capybara::Webkit::Driver.new(app, { set_skip_image_loading: true })
+  driver
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    # Choose a test framework:
+    with.test_framework :rspec
+    with.library :rails
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,19 @@ require 'rspec/retry'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |file| require file }
 
+Capybara.register_driver :webkit do |app|
+  driver = Capybara::Webkit::Driver.new(app, { set_skip_image_loading: true })
+  driver
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    # Choose a test framework:
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 SimpleCov.start do
   add_group "Models", "app/models"
   add_group "Controllers", "app/controllers"
@@ -82,6 +95,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.backtrace_exclusion_patterns << /\/gems\//
+
   config.default_sleep_interval = 2
   config.verbose_retry = true
   config.default_retry_count = 4
@@ -92,7 +107,7 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-
+=begin
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
@@ -126,27 +141,12 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  # config.order = :random
+  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-
-  config.backtrace_exclusion_patterns << /gems/
-
-end
-
-Capybara.register_driver :webkit do |app|
-  driver = Capybara::Webkit::Driver.new(app, { set_skip_image_loading: true })
-  driver
-end
-
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    # Choose a test framework:
-    with.test_framework :rspec
-    with.library :rails
-  end
+=end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,7 @@ RSpec.configure do |config|
 
   config.default_sleep_interval = 2
   config.verbose_retry = true
-  config.default_retry_count = 0##TODO: SET BACK TO 4!!!!
+  config.default_retry_count = 4
 
   config.retry_callback = proc do |ex|
     Capybara.reset!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,7 @@ RSpec.configure do |config|
 
   config.default_sleep_interval = 2
   config.verbose_retry = true
-  config.default_retry_count = 4
+  config.default_retry_count = 0##TODO: SET BACK TO 4!!!!
 
   config.retry_callback = proc do |ex|
     Capybara.reset!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,7 @@ RSpec.configure do |config|
 
   config.default_sleep_interval = 2
   config.verbose_retry = true
-  config.default_retry_count = 4
+  config.default_retry_count = 8
 
   config.retry_callback = proc do |ex|
     Capybara.reset!

--- a/spec/support/data_helper.rb
+++ b/spec/support/data_helper.rb
@@ -21,7 +21,7 @@
 module DataHelpers
 
   def create_and_assign_protocol_with_a_single_service
-    identity              = Identity.first
+    identity              = @logged_in_identity
     sub_service_request   = create(:sub_service_request_with_organization)
     protocol              = create(:protocol_with_single_service, sub_service_request: sub_service_request)
     organization_provider = create(:organization_provider, name: "Provider")
@@ -35,7 +35,7 @@ module DataHelpers
   end
 
   def create_and_assign_protocol_with_duplicate_services
-    identity              = Identity.first
+    identity              = @logged_in_identity
     sub_service_request   = create(:sub_service_request_with_organization)
     protocol              = create(:protocol_with_duplicate_services, sub_service_request: sub_service_request)
     organization_provider = create(:organization_provider, name: "Provider")
@@ -49,7 +49,7 @@ module DataHelpers
   end
 
   def create_and_assign_protocol_to_me
-    identity              = Identity.first
+    identity              = @logged_in_identity
     sub_service_request   = create(:sub_service_request_with_organization)
     subsidy               = create(:subsidy, sub_service_request: sub_service_request)
     protocol              = create(:protocol_imported_from_sparc, sub_service_request: sub_service_request)
@@ -64,7 +64,7 @@ module DataHelpers
   end
 
   def create_and_assign_protocol_without_services_to_me
-    identity              = Identity.first
+    identity              = @logged_in_identity
     sub_service_request   = create(:sub_service_request_with_organization)
     protocol              = create(:protocol_imported_from_sparc, :without_services, sub_service_request: sub_service_request)
     organization_provider = create(:organization_provider, name: "Provider")
@@ -78,7 +78,7 @@ module DataHelpers
   end
 
   def create_and_assign_blank_protocol_to_me
-    identity              = Identity.first
+    identity              = @logged_in_identity
     protocol              = create(:protocol_with_sub_service_request)
     organization          = protocol.organization
     organization_provider = create(:organization_provider, name: "Provider")

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -30,17 +30,17 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each, type: :feature) do
-    FEATURE_TEST_MODELS.each do |model|
-      DatabaseCleaner[:active_record, model: model].strategy = :truncation
-      DatabaseCleaner[:active_record, model: model].start
-    end
-  end
+  # config.before(:each, type: :feature) do
+  #   FEATURE_TEST_MODELS.each do |model|
+  #     DatabaseCleaner[:active_record, model: model].strategy = :truncation
+  #     DatabaseCleaner[:active_record, model: model].start
+  #   end
+  # end
 
   # Clean data post-test
-  config.append_after(:each, type: :feature) do
-    FEATURE_TEST_MODELS.each do |model|
-      DatabaseCleaner[:active_record, model: model].clean
-    end
-  end
+  # config.append_after(:each, type: :feature) do
+  #   FEATURE_TEST_MODELS.each do |model|
+  #     DatabaseCleaner[:active_record, model: model].clean
+  #   end
+  # end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -20,7 +20,7 @@
 
 RSpec.configure do |config|
   MODELS = ActiveRecord::Base.descendants.select { |model| model.respond_to?(:sparc_record?) }
-  # MODELS = [Identity, Sparc::Protocol]
+  FEATURE_TEST_MODELS = [Identity]
 
   # Clean data before running the suite
   config.before(:suite) do
@@ -30,17 +30,17 @@ RSpec.configure do |config|
     end
   end
 
-  # config.before(:each) do
-  #   MODELS.each do |model|
-  #     DatabaseCleaner[:active_record, model: model].strategy = :truncation
-  #     DatabaseCleaner[:active_record, model: model].start
-  #   end
-  # end
+  config.before(:each, type: :feature) do
+    FEATURE_TEST_MODELS.each do |model|
+      DatabaseCleaner[:active_record, model: model].strategy = :truncation
+      DatabaseCleaner[:active_record, model: model].start
+    end
+  end
 
   # Clean data post-test
-  # config.append_after(:each) do
-  #   MODELS.each do |model|
-  #     DatabaseCleaner[:active_record, model: model].clean
-  #   end
-  # end
+  config.append_after(:each, type: :feature) do
+    FEATURE_TEST_MODELS.each do |model|
+      DatabaseCleaner[:active_record, model: model].clean
+    end
+  end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -20,6 +20,7 @@
 
 RSpec.configure do |config|
   MODELS = ActiveRecord::Base.descendants.select { |model| model.respond_to?(:sparc_record?) }
+  # MODELS = [Identity, Sparc::Protocol]
 
   # Clean data before running the suite
   config.before(:suite) do
@@ -29,22 +30,17 @@ RSpec.configure do |config|
     end
   end
 
-  # Set default strategy to transaction
-  config.before(:each) do
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.start
-
-    MODELS.each do |model|
-      DatabaseCleaner[:active_record, model: model].strategy = :truncation
-      DatabaseCleaner[:active_record, model: model].start
-    end
-  end
+  # config.before(:each) do
+  #   MODELS.each do |model|
+  #     DatabaseCleaner[:active_record, model: model].strategy = :truncation
+  #     DatabaseCleaner[:active_record, model: model].start
+  #   end
+  # end
 
   # Clean data post-test
-  config.append_after(:each) do
-    DatabaseCleaner.clean
-    MODELS.each do |model|
-      DatabaseCleaner[:active_record, model: model].clean
-    end
-  end
+  # config.append_after(:each) do
+  #   MODELS.each do |model|
+  #     DatabaseCleaner[:active_record, model: model].clean
+  #   end
+  # end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -20,7 +20,7 @@
 
 RSpec.configure do |config|
   MODELS = ActiveRecord::Base.descendants.select { |model| model.respond_to?(:sparc_record?) }
-  FEATURE_TEST_MODELS = [Identity]
+  # FEATURE_TEST_MODELS = [Identity]
 
   # Clean data before running the suite
   config.before(:suite) do

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -35,6 +35,8 @@ module ControllerMacros
       @request.env['devise.mapping']  = Devise.mappings[:identity]
       identity                        = Identity.first || create(:identity)
 
+      @logged_in_identity = identity
+
       sign_in identity
     end
   end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -22,6 +22,7 @@ module DeviseHelpers
 
   def sign_in
     identity = Identity.first || create(:identity)
+    @logged_in_identity = identity
 
     login_as(identity, run_callbacks: false)
   end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -21,7 +21,7 @@
 module DeviseHelpers
 
   def sign_in
-    identity = create(:identity)
+    identity = Identity.first || create(:identity)
 
     login_as(identity, run_callbacks: false)
   end
@@ -33,7 +33,7 @@ module ControllerMacros
 
     before(:each) do
       @request.env['devise.mapping']  = Devise.mappings[:identity]
-      identity                        = create(:identity)##TODO: This should really check for an existing identity first
+      identity                        = Identity.first || create(:identity)
 
       sign_in identity
     end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -33,7 +33,7 @@ module ControllerMacros
 
     before(:each) do
       @request.env['devise.mapping']  = Devise.mappings[:identity]
-      identity                        = create(:identity)
+      identity                        = create(:identity)##TODO: This should really check for an existing identity first
 
       sign_in identity
     end

--- a/spec/support/features/visit_helpers.rb
+++ b/spec/support/features/visit_helpers.rb
@@ -37,7 +37,7 @@ module Features
       visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
       wait_for_ajax
       
-      page.find('a.list-group-item[data-appointment-id="1"]').click
+      first('a.list-group-item.appointment-link').click
       wait_for_ajax
     end
 
@@ -45,7 +45,7 @@ module Features
       visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
       wait_for_ajax
 
-      page.find('a.list-group-item[data-appointment-id="1"]').click
+      first('a.list-group-item.appointment-link').click
       wait_for_ajax
       
       find('a.btn.start-appointment').click


### PR DESCRIPTION
Bringing into parity with sparc, and removing blanket calls to database cleaner for every single test. This is insanely costly, and we should instead only clean out the sparc-shard database when the specs requires it to be cleaned out.