### PR TITLE
updated firefox logo to match with sparc os

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -60,7 +60,7 @@
               = image_tag "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Google_Chrome_icon_%28September_2014%29.svg/512px-Google_Chrome_icon_%28September_2014%29.svg.png", alt: "Chrome icon", width: 18
               = t('layout.footer.browsers.chrome')
             %li.mb-1
-              = image_tag "https://upload.wikimedia.org/wikipedia/commons/thumb/7/78/Mozilla_Firefox_logo_2009.png/512px-Mozilla_Firefox_logo_2009.png", alt: "Firefox icon", width: 18, title: "Mozilla Foundation (MPL 1.1 &lt;https://www.mozilla.org/MPL/1.1/&gt;, GPL &lt;http://www.gnu.org/licenses/gpl.html&gt; or LGPL &lt;http://www.gnu.org/licenses/lgpl.html&gt;), via Wikimedia Commons"
+              = image_tag "https://upload.wikimedia.org/wikipedia/commons/7/7a/Firefox_brand_logo%2C_2019.svg", alt: "Firefox icon", width: 18, title: "Mozilla Foundation (MPL 1.1 &lt;https://www.mozilla.org/MPL/1.1/&gt;, GPL &lt;http://www.gnu.org/licenses/gpl.html&gt; or LGPL &lt;http://www.gnu.org/licenses/lgpl.html&gt;), via Wikimedia Commons"
               = t('layout.footer.browsers.firefox')
             %li.mb-1
               = image_tag "https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/Safari_browser_logo.svg/128px-Safari_browser_logo.svg.png", alt: "Safari icon", width: 18


### PR DESCRIPTION
Relevant to https://www.pivotaltracker.com/story/show/183806621

quick fix for the broken firefox icon.  ensured that it matches presentation in SPARC OS for consistency across SPARC products.