### PR TITLE
JV - Remove Calendar and Service Edit Functions in Clinical Services Tab

### DIFF
--- a/app/views/study_schedule/management/_schedule_edit_buttons.html.haml
+++ b/app/views/study_schedule/management/_schedule_edit_buttons.html.haml
@@ -18,32 +18,37 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-#study_schedule_buttons{ data: { protocol_id: protocol.id } }
-  .row
-    .col-sm-4.col-md-4.text-center.h5
-      =t(:protocol)[:study_schedule][:manage_arms]
-      #manage_arms.mt-1
-        = link_to new_arm_path(protocol_id: protocol.id, schedule_tab: tab), remote: true, class: 'btn btn-success btn-sm mr-1', title: t('protocol.study_schedule.add_arm'), type: 'button', aria: { label: 'Add Arm' }, data: { toggle: 'tooltip', animation: 'false' } do
-          = icon('fas', 'plus')
-        = link_to navigate_arms_path(protocol_id: protocol.id, intended_action: 'destroy'), remote: true, class: 'btn btn-danger btn-sm mr-1', title: t('protocol.study_schedule.remove_arm'), type: 'button', aria: { label: 'Remove Arm' }, data: { toggle: 'tooltip', animation: 'false' } do
-          = icon('fas', 'minus')
-        = link_to navigate_arms_path(protocol_id: protocol.id, intended_action: 'edit'), remote: true, class: 'btn btn-warning btn-sm', title: t('protocol.study_schedule.edit_arm'), type: 'button', aria: { label: 'Edit Arm' }, data: { toggle: 'tooltip', animation: 'false' } do
-          = icon('fas', 'edit')
+.alert.alert-warning.mb-0.rounded-0.border-bottom
+  %p.text-warning.mb-0
+    = icon('fas', 'exclamation-circle mr-1')
+    = t(:line_item)[:edit_clincal_services_in_sparc]
+-# Infrastructure for managing calendar and services edits still exists, but is commented out here in favor of these edits being made solely in SPARCDashboard.
+-##study_schedule_buttons{ data: { protocol_id: protocol.id } }
+  -#.row
+    -#.col-sm-4.col-md-4.text-center.h5
+      -#=t(:protocol)[:study_schedule][:manage_arms]
+      -##manage_arms.mt-1
+        -#= link_to new_arm_path(protocol_id: protocol.id, schedule_tab: tab), remote: true, class: 'btn btn-success btn-sm mr-1', title: t('protocol.study_schedule.add_arm'), type: 'button', aria: { label: 'Add Arm' }, data: { toggle: 'tooltip', animation: 'false' } do
+          -#= icon('fas', 'plus')
+        -#= link_to navigate_arms_path(protocol_id: protocol.id, intended_action: 'destroy'), remote: true, class: 'btn btn-danger btn-sm mr-1', title: t('protocol.study_schedule.remove_arm'), type: 'button', aria: { label: 'Remove Arm' }, data: { toggle: 'tooltip', animation: 'false' } do
+          -#= icon('fas', 'minus')
+        -#= link_to navigate_arms_path(protocol_id: protocol.id, intended_action: 'edit'), remote: true, class: 'btn btn-warning btn-sm', title: t('protocol.study_schedule.edit_arm'), type: 'button', aria: { label: 'Edit Arm' }, data: { toggle: 'tooltip', animation: 'false' } do
+          -#= icon('fas', 'edit')
 
-    .col-sm-4.col-md-4.text-center.h5
-      =t(:protocol)[:study_schedule][:manage_visits]
-      #manage_visit_groups.mt-1
-        = link_to 'javascript:;', id: 'add_visit_group_button', class: 'btn btn-success btn-sm mr-1', title: t('protocol.study_schedule.add_visit_group'), type: 'button', aria: { label: 'Add Visit Group' }, data: { toggle: 'tooltip', animation: 'false' } do
-          = icon('fas', 'plus')
-        = link_to 'javascript:;', id: 'remove_visit_group_button', class: 'btn btn-danger btn-sm mr-1', title: t('protocol.study_schedule.remove_visit_group'), type: 'button', aria: { label: 'Remove Visit Group' }, data: { toggle: 'tooltip', animation: 'false' } do
-          = icon('fas', 'minus')
-        = link_to 'javascript:;', id: 'edit_visit_group_button', class: 'btn btn-warning btn-sm', title: t('protocol.study_schedule.edit_visit_group'), type: 'button', aria: { label: 'Edit Visit Group' }, data: { toggle: 'tooltip', animation: 'false' } do
-          = icon('fas', 'edit')
-    .col-sm-4.col-md-4.text-center.h5
-      =t(:protocol)[:study_schedule][:manage_services]
-      #manage_services.mt-1
-        = link_to 'javascript:;', id: 'add_service_button', class: 'btn btn-success btn-sm mr-1', title: t('protocol.study_schedule.add_service'), type: 'button', aria: { label: 'Add Service' }, data: { toggle: 'tooltip', animation: 'false' } do
-          = icon('fas', 'plus')
+    -#.col-sm-4.col-md-4.text-center.h5
+      -#=t(:protocol)[:study_schedule][:manage_visits]
+      -##manage_visit_groups.mt-1
+        -#= link_to 'javascript:;', id: 'add_visit_group_button', class: 'btn btn-success btn-sm mr-1', title: t('protocol.study_schedule.add_visit_group'), type: 'button', aria: { label: 'Add Visit Group' }, data: { toggle: 'tooltip', animation: 'false' } do
+          -#= icon('fas', 'plus')
+        -#= link_to 'javascript:;', id: 'remove_visit_group_button', class: 'btn btn-danger btn-sm mr-1', title: t('protocol.study_schedule.remove_visit_group'), type: 'button', aria: { label: 'Remove Visit Group' }, data: { toggle: 'tooltip', animation: 'false' } do
+          -#= icon('fas', 'minus')
+        -#= link_to 'javascript:;', id: 'edit_visit_group_button', class: 'btn btn-warning btn-sm', title: t('protocol.study_schedule.edit_visit_group'), type: 'button', aria: { label: 'Edit Visit Group' }, data: { toggle: 'tooltip', animation: 'false' } do
+          -#= icon('fas', 'edit')
+    -#.col-sm-4.col-md-4.text-center.h5
+      -#=t(:protocol)[:study_schedule][:manage_services]
+      -##manage_services.mt-1
+        -#= link_to 'javascript:;', id: 'add_service_button', class: 'btn btn-success btn-sm mr-1', title: t('protocol.study_schedule.add_service'), type: 'button', aria: { label: 'Add Service' }, data: { toggle: 'tooltip', animation: 'false' } do
+          -#= icon('fas', 'plus')
 
-        = link_to 'javascript:;', id: 'remove_service_button', class: 'btn btn-danger btn-sm', title: t('protocol.study_schedule.remove_service'), type: 'button', aria: { label: 'Remove Service' }, data: { toggle: 'tooltip', animation: 'false' } do
-          = icon('fas', 'minus')
+        -#= link_to 'javascript:;', id: 'remove_service_button', class: 'btn btn-danger btn-sm', title: t('protocol.study_schedule.remove_service'), type: 'button', aria: { label: 'Remove Service' }, data: { toggle: 'tooltip', animation: 'false' } do
+          -#= icon('fas', 'minus')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,6 +385,7 @@ en:
     documents: "Documents"
     edit: "Edit Non-clinical Service"
     edit_in_sparc: "Only Account and Contact fields can be edited for non-clinical services. All other editing should be done in SPARCDashboard"
+    edit_clincal_services_in_sparc: "All calendar revisions must be completed in SPARCDashboard."
     flash_messages:
       created: "Non-clinical Service Created"
       deleted: "Non-clinical Service Deleted"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_14_190943) do
+ActiveRecord::Schema.define(version: 2021_12_09_132802) do
 
-  create_table "appointment_statuses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "appointment_statuses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "status"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.integer "appointment_id"
   end
 
-  create_table "appointments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "appointments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.integer "visit_group_id"
     t.integer "visit_group_position"
@@ -36,11 +36,12 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.integer "arm_id"
     t.integer "protocols_participant_id"
     t.index ["arm_id"], name: "index_appointments_on_arm_id"
+    t.index ["protocols_participant_id"], name: "index_appointments_on_protocols_participant_id"
     t.index ["sparc_id"], name: "index_appointments_on_sparc_id"
     t.index ["type"], name: "index_appointments_on_type"
   end
 
-  create_table "arms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "arms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.integer "protocol_id"
     t.string "name"
@@ -49,12 +50,13 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
+    t.boolean "marked_for_deletion", default: false
     t.index ["deleted_at"], name: "index_arms_on_deleted_at"
     t.index ["protocol_id"], name: "index_arms_on_protocol_id"
     t.index ["sparc_id"], name: "index_arms_on_sparc_id"
   end
 
-  create_table "components", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "components", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "component"
     t.integer "position"
     t.integer "composable_id"
@@ -66,7 +68,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["composable_id", "composable_type"], name: "index_components_on_composable_id_and_composable_type"
   end
 
-  create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", limit: 4294967295, null: false
@@ -81,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "documents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "documents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "documentable_id"
     t.string "documentable_type"
     t.datetime "deleted_at"
@@ -97,7 +99,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["documentable_id", "documentable_type"], name: "index_documents_on_documentable_id_and_documentable_type"
   end
 
-  create_table "fulfillments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "fulfillments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.integer "line_item_id"
     t.datetime "fulfilled_at"
@@ -123,7 +125,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["sparc_id"], name: "index_fulfillments_on_sparc_id"
   end
 
-  create_table "identity_counters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "identity_counters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "identity_id"
     t.integer "tasks_count", default: 0
     t.datetime "created_at", null: false
@@ -132,7 +134,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["identity_id"], name: "index_identity_counters_on_identity_id"
   end
 
-  create_table "imports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "imports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -147,7 +149,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.datetime "xml_file_updated_at"
   end
 
-  create_table "line_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "line_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.integer "arm_id"
     t.integer "service_id"
@@ -168,7 +170,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["sparc_id"], name: "index_line_items_on_sparc_id"
   end
 
-  create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "identity_id"
     t.text "comment"
     t.datetime "deleted_at"
@@ -182,7 +184,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["notable_id", "notable_type"], name: "index_notes_on_notable_id_and_notable_type"
   end
 
-  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.string "action"
     t.string "callback_url"
@@ -192,7 +194,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["sparc_id"], name: "index_notifications_on_sparc_id"
   end
 
-  create_table "participants", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "participants", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "first_name", collation: "utf8_unicode_ci"
     t.string "last_name", collation: "utf8_unicode_ci"
     t.string "mrn"
@@ -215,7 +217,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["mrn"], name: "index_participants_on_mrn"
   end
 
-  create_table "procedures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "procedures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.integer "appointment_id"
     t.string "service_name"
@@ -244,7 +246,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["visit_id"], name: "index_procedures_on_visit_id"
   end
 
-  create_table "protocols", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "protocols", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.string "sponsor_name"
     t.string "udak_project_number"
@@ -263,7 +265,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["sub_service_request_id"], name: "index_protocols_on_sub_service_request_id"
   end
 
-  create_table "protocols_participants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "protocols_participants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.bigint "protocol_id"
     t.bigint "participant_id"
     t.bigint "arm_id"
@@ -280,7 +282,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["protocol_id"], name: "index_protocols_participants_on_protocol_id"
   end
 
-  create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
     t.datetime "created_at"
@@ -289,7 +291,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "tasks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "tasks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.date "due_at"
     t.boolean "complete", default: false
     t.datetime "deleted_at"
@@ -305,7 +307,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["identity_id"], name: "index_tasks_on_identity_id"
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -326,7 +328,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
@@ -337,7 +339,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "visit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "visit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.integer "arm_id"
     t.integer "position"
@@ -354,7 +356,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_190943) do
     t.index ["sparc_id"], name: "index_visit_groups_on_sparc_id"
   end
 
-  create_table "visits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "visits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
     t.integer "sparc_id"
     t.integer "line_item_id"
     t.integer "visit_group_id"

--- a/spec/features/appointments/identity_changes_participant_arm_spec.rb
+++ b/spec/features/appointments/identity_changes_participant_arm_spec.rb
@@ -20,24 +20,26 @@
 
 require 'rails_helper'
 
+# These commented-out tests relate to editing calendar and services functions on a protocol's clinical services tab. While these functions are no longer rendered to the view, the infrastructure is still in place. Commenting these tests out so they do not fail during the Travis build, 12/7/22.
+
 feature "Change Participant Arm", js: :true do
-  context "original arm does NOT have completed procedures" do
-    scenario "User changes arm on the participant tracker" do
-      when_i_start_work_on_an_appointment
-      then_i_change_the_arm_of_the_participant
-      and_i_visit_the_calendar_again
-      i_should_only_see_new_appointments
-    end
-  end
-  context "original arm has completed procedures" do
-    scenario "User changes arm on the participant tracker" do
-      when_i_start_work_on_an_appointment
-      and_i_complete_a_procedure
-      then_i_change_the_arm_of_the_participant
-      and_i_visit_the_calendar_again
-      i_should_see_new_and_old_appointments
-    end
-  end
+  #context "original arm does NOT have completed procedures" do
+    #scenario "User changes arm on the participant tracker" do
+      #when_i_start_work_on_an_appointment
+      #then_i_change_the_arm_of_the_participant
+      #and_i_visit_the_calendar_again
+      #i_should_only_see_new_appointments
+    #end
+  #end
+  #context "original arm has completed procedures" do
+    #scenario "User changes arm on the participant tracker" do
+      #when_i_start_work_on_an_appointment
+      #and_i_complete_a_procedure
+      #then_i_change_the_arm_of_the_participant
+      #and_i_visit_the_calendar_again
+      #i_should_see_new_and_old_appointments
+    #end
+  #end
 
 
   def when_i_start_work_on_an_appointment

--- a/spec/features/study_schedule/management/identity_edits_arms_spec.rb
+++ b/spec/features/study_schedule/management/identity_edits_arms_spec.rb
@@ -20,58 +20,60 @@
 
 require 'rails_helper'
 
+# These commented-out tests relate to editing calendar and services functions on a protocol's clinical services tab. While these functions are no longer rendered to the view, the infrastructure is still in place. Commenting these tests out so they do not fail during the Travis build, 12/7/22.
+
 feature 'Identity edits arms on protocol study schedule', js: true do
 
-  context 'User adds an arm' do
-    scenario 'and sees the new arm is created' do
-      given_i_am_viewing_a_protocol_with_one_arm
-      when_i_click_the_add_arm_button
-      when_i_fill_in_the_form
-      when_i_click_the_add_submit_button
-      then_i_should_see_the_new_arm
-    end
-  end
+  #context 'User adds an arm' do
+    #scenario 'and sees the new arm is created' do
+      #given_i_am_viewing_a_protocol_with_one_arm
+      #when_i_click_the_add_arm_button
+      #when_i_fill_in_the_form
+      #when_i_click_the_add_submit_button
+      #then_i_should_see_the_new_arm
+    #end
+  #end
 
-  context 'User edits an arm' do
-    scenario 'and sees the updated arm' do
-      given_i_am_viewing_a_protocol_with_one_arm
-      when_i_click_the_edit_arm_button
-      when_i_set_the_name_to 'other arm name'
-      when_i_set_the_subject_count_to 1234
-      when_i_click_the_save_submit_button
-      then_i_should_see_the_updated_arm
-    end
-  end
+  #context 'User edits an arm' do
+    #scenario 'and sees the updated arm' do
+      #given_i_am_viewing_a_protocol_with_one_arm
+      #when_i_click_the_edit_arm_button
+      #when_i_set_the_name_to 'other arm name'
+      #when_i_set_the_subject_count_to 1234
+      #when_i_click_the_save_submit_button
+      #then_i_should_see_the_updated_arm
+    #end
+  #end
 
-  context 'User deletes an arm' do
-    scenario 'and does not see the arm' do
-      given_i_am_viewing_a_protocol_with_multiple_arms
-      when_i_click_the_remove_arm_button
-      and_i_select_the_first_arm
-      when_i_click_the_remove_submit_button
-      then_i_should_not_see_the_arm
-    end
-  end
+  #context 'User deletes an arm' do
+    #scenario 'and does not see the arm' do
+      #given_i_am_viewing_a_protocol_with_multiple_arms
+      #when_i_click_the_remove_arm_button
+      #and_i_select_the_first_arm
+      #when_i_click_the_remove_submit_button
+      #then_i_should_not_see_the_arm
+    #end
+  #end
 
-  context 'User tries to delete an arm with fulfillments' do
-    scenario 'and sees the arm' do
-      given_i_am_viewing_a_protocol_with_multiple_arms
-      given_there_is_an_arm_with_completed_procedures
-      when_i_click_the_remove_arm_button
-      when_i_select_the_arm_with_completed_procedures
-      when_i_click_the_remove_submit_button
-      then_i_should_see_an_error_about_completed_procedures
-    end
-  end
+  #context 'User tries to delete an arm with fulfillments' do
+    #scenario 'and sees the arm' do
+      #given_i_am_viewing_a_protocol_with_multiple_arms
+      #given_there_is_an_arm_with_completed_procedures
+      #when_i_click_the_remove_arm_button
+      #when_i_select_the_arm_with_completed_procedures
+      #when_i_click_the_remove_submit_button
+      #then_i_should_see_an_error_about_completed_procedures
+    #end
+  #end
 
-  context 'User tries to delete the last arm' do
-    scenario 'and sees the arm' do
-      given_i_am_viewing_a_protocol_with_one_arm
-      when_i_click_the_remove_arm_button
-      when_i_click_the_remove_submit_button
-      then_i_should_see_an_error_about_last_arm
-    end
-  end
+  #context 'User tries to delete the last arm' do
+    #scenario 'and sees the arm' do
+      #given_i_am_viewing_a_protocol_with_one_arm
+      #when_i_click_the_remove_arm_button
+      #when_i_click_the_remove_submit_button
+      #then_i_should_see_an_error_about_last_arm
+    #end
+  #end
 
 
   def given_i_am_viewing_a_protocol_with_one_arm

--- a/spec/features/study_schedule/management/identity_edits_services_spec.rb
+++ b/spec/features/study_schedule/management/identity_edits_services_spec.rb
@@ -20,29 +20,31 @@
 
 require 'rails_helper'
 
+# These commented-out tests relate to editing calendar and services functions on a protocol's clinical services tab. While these functions are no longer rendered to the view, the infrastructure is still in place. Commenting these tests out so they do not fail during the Travis build, 12/7/22.
+
 feature 'Identity edits services for a particular protocol', js: true, enqueue: false do
 
-  context 'User adds a service to an arm' do
-    scenario 'and sees the service on the arm' do
-      given_i_am_viewing_a_protocol
-      given_an_arm_has_services
-      when_i_click_the_add_services_button
-      when_i_fill_in_the_form
-      when_i_click_the_add_submit_button
-      then_i_should_see_it_on_that_arm
-    end
-  end
+  #context 'User adds a service to an arm' do
+    #scenario 'and sees the service on the arm' do
+      #given_i_am_viewing_a_protocol
+      #given_an_arm_has_services
+      #when_i_click_the_add_services_button
+      #when_i_fill_in_the_form
+      #when_i_click_the_add_submit_button
+      #then_i_should_see_it_on_that_arm
+    #end
+  #end
 
-  context 'User deletes a service from an arm' do
-    scenario 'and sees the service is gone' do
-      given_i_am_viewing_a_protocol
-      given_an_arm_has_services
-      when_i_click_the_remove_services_button
-      when_i_select_a_service_and_arm
-      when_i_click_the_remove_submit_button
-      then_i_should_not_see_it_on_that_arm
-    end
-  end
+  #context 'User deletes a service from an arm' do
+    #scenario 'and sees the service is gone' do
+      #given_i_am_viewing_a_protocol
+      #given_an_arm_has_services
+      #when_i_click_the_remove_services_button
+      #when_i_select_a_service_and_arm
+      #when_i_click_the_remove_submit_button
+      #then_i_should_not_see_it_on_that_arm
+    #end
+  #end
 
   def given_i_am_viewing_a_protocol
     @protocol  = create_and_assign_protocol_to_me

--- a/spec/features/study_schedule/management/identity_edits_visit_groups_spec.rb
+++ b/spec/features/study_schedule/management/identity_edits_visit_groups_spec.rb
@@ -20,85 +20,87 @@
 
 require 'rails_helper'
 
+# These commented-out tests relate to editing calendar and services functions on a protocol's clinical services tab. While these functions are no longer rendered to the view, the infrastructure is still in place. Commenting these tests out so they do not fail during the Travis build, 12/7/22.
+
 feature 'Identity edits visit groups for a particular protocol', js: true do
 
-  context "User adds a visit group to an arm" do
-    scenario "and sees the visit group on the arm" do
-      given_i_am_viewing_an_arm_with_multiple_visit_groups
+  #context "User adds a visit group to an arm" do
+    #scenario "and sees the visit group on the arm" do
+      #given_i_am_viewing_an_arm_with_multiple_visit_groups
 
-      @original_visit_group_1 = @arm.visit_groups.first
-      @original_visit_group_2 = @arm.visit_groups.second
-      @original_visit_group_1.day = 1
-      @original_visit_group_2.day = 3
-      @original_visit_group_1.save
-      @original_visit_group_2.save
+      #@original_visit_group_1 = @arm.visit_groups.first
+      #@original_visit_group_2 = @arm.visit_groups.second
+      #@original_visit_group_1.day = 1
+      #@original_visit_group_2.day = 3
+      #@original_visit_group_1.save
+      #@original_visit_group_2.save
 
-      when_i_click_the_add_visit_group_button
-      when_i_fill_in_the_form(day: @arm.visit_groups.last.day + 100)
-      when_i_click_the_add_submit_button
-      then_i_should_see_the_visit_group
-    end
+      #when_i_click_the_add_visit_group_button
+      #when_i_fill_in_the_form(day: @arm.visit_groups.last.day + 100)
+      #when_i_click_the_add_submit_button
+      #then_i_should_see_the_visit_group
+    #end
 
-    scenario "and sees it in the correct position" do
-      given_i_am_viewing_an_arm_with_multiple_visit_groups
+    #scenario "and sees it in the correct position" do
+      #given_i_am_viewing_an_arm_with_multiple_visit_groups
 
-      @original_visit_group_1 = @arm.visit_groups.first
-      @original_visit_group_2 = @arm.visit_groups.second
-      @original_visit_group_1.day = 1
-      @original_visit_group_2.day = 3
-      @original_visit_group_1.save
-      @original_visit_group_2.save
+      #@original_visit_group_1 = @arm.visit_groups.first
+      #@original_visit_group_2 = @arm.visit_groups.second
+      #@original_visit_group_1.day = 1
+      #@original_visit_group_2.day = 3
+      #@original_visit_group_1.save
+      #@original_visit_group_2.save
 
 
-      when_i_click_the_add_visit_group_button
-      when_i_fill_in_the_form(position: "Before #{@arm.visit_groups.second.name} (Day #{@arm.visit_groups.second.day})", day: @arm.visit_groups.second.day-1)
-      when_i_click_the_add_submit_button
-      then_i_should_see_the_position_is 1
-    end
-  end
+      #when_i_click_the_add_visit_group_button
+      #when_i_fill_in_the_form(position: "Before #{@arm.visit_groups.second.name} (Day #{@arm.visit_groups.second.day})", day: @arm.visit_groups.second.day-1)
+      #when_i_click_the_add_submit_button
+      #then_i_should_see_the_position_is 1
+    #end
+  #end
 
-  context "User edits a visit group on an arm" do
-    scenario "and sees the updated arm" do
-      given_i_am_viewing_an_arm_with_multiple_visit_groups
-      when_i_click_the_edit_visit_group_button
-      when_i_set_the_name_to 'VG 2'
-      wait_for_ajax
-      when_i_set_the_day_to 2
-      wait_for_ajax
-      sleep 2
-      when_i_click_the_save_submit_button
-      then_i_should_see_the_updated_visit_group
-    end
-  end
+  #context "User edits a visit group on an arm" do
+    #scenario "and sees the updated arm" do
+      #given_i_am_viewing_an_arm_with_multiple_visit_groups
+      #when_i_click_the_edit_visit_group_button
+      #when_i_set_the_name_to 'VG 2'
+      #wait_for_ajax
+      #when_i_set_the_day_to 2
+      #wait_for_ajax
+      #sleep 2
+      #when_i_click_the_save_submit_button
+      #then_i_should_see_the_updated_visit_group
+    #end
+  #end
 
-  context "User edits a visit groups name in the service calendar" do
-    context "and provides a name" do
-      scenario "and sees the updated name" do
-        given_i_am_viewing_an_arm_with_one_visit_group
-        when_i_enter_the_name "VG YO"
-        then_i_should_see_the_name "VG YO"
-      end
-    end
+  #context "User edits a visit groups name in the service calendar" do
+    #context "and provides a name" do
+      #scenario "and sees the updated name" do
+        #given_i_am_viewing_an_arm_with_one_visit_group
+        #when_i_enter_the_name "VG YO"
+        #then_i_should_see_the_name "VG YO"
+      #end
+    #end
 
-    context "and leaves the name blank" do
-      scenario "and sees the original name" do
-        given_i_am_viewing_an_arm_with_one_visit_group
-        @original_name = @arm.visit_groups.first.name
+    #context "and leaves the name blank" do
+      #scenario "and sees the original name" do
+        #given_i_am_viewing_an_arm_with_one_visit_group
+        #@original_name = @arm.visit_groups.first.name
 
-        when_i_enter_the_name ""
-        then_i_should_see_the_original_name
-      end
-    end
-  end
+        #when_i_enter_the_name ""
+        #then_i_should_see_the_original_name
+      #end
+    #end
+  #end
 
-  context "User deletes a visit group from an arm" do
-    scenario "and does not see the visit group on the arm" do
-      given_i_am_viewing_an_arm_with_multiple_visit_groups
-      when_i_click_the_remove_visit_group_button
-      when_i_click_the_remove_submit_button
-      then_i_should_not_see_the_visit_group
-    end
-  end
+  #context "User deletes a visit group from an arm" do
+    #scenario "and does not see the visit group on the arm" do
+      #given_i_am_viewing_an_arm_with_multiple_visit_groups
+      #when_i_click_the_remove_visit_group_button
+      #when_i_click_the_remove_submit_button
+      #then_i_should_not_see_the_visit_group
+    #end
+  #end
 
   def given_i_am_viewing_an_arm_with_multiple_visit_groups
     @protocol = create_and_assign_protocol_to_me


### PR DESCRIPTION
Prevents rendering of calendar edit and service edit functions from inside a given protocol's clinical services tab. Replaces those renderings with a prompt to conduct all such edits in SPARCDashboard.

https://www.pivotaltracker.com/story/show/161257935

[#161257935]