### PR TITLE
GM - Non-clinical services auditing report updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ fulfill.sql
 public/system/*
 
 /node_modules
+lib/tasks/auto_annotate_models.rake
+.gitignore
+.vscode/

--- a/lib/reports/auditing_report.rb
+++ b/lib/reports/auditing_report.rb
@@ -116,12 +116,15 @@ class AuditingReport < Report
         header << "Documents"
         header << "Fields Modified"
         header << "Date"
+        header << "Quantity of Each Service Completed"
+        header << "What was the Charge"
+        header << "Who was the Payer"
 
         csv << header
 
         protocols.each do |protocol|
           protocol.line_items.each do |line_item|
-            next unless line_item.versions.where(event: ["create", "update"], created_at: @start_date..@end_date).any?
+            next unless line_item.versions.where(event: ["create", "update"], created_at: @start_date..@end_date).any? && line_item.service.one_time_fee?
             line_item.versions.where(event: ["create", "update"]).each do |version|
               data = [ protocol.srid ]
               data << protocol.research_master_id if ENV.fetch('RMID_URL'){nil}
@@ -142,6 +145,10 @@ class AuditingReport < Report
               data << line_item.documents.map(&:title).join(' | ')
               data << changeset_formatter(version.changeset)
               data << format_date(version.created_at)
+              data << line_item.fulfillments.map(&:quantity).join(' | ')
+              data << line_item.fulfillments.map{ |f| display_cost(f.service_cost)}.join(' | ')
+              data << line_item.fulfillments.map(&:funding_source).join(' | ')
+
 
               csv << data
             end
@@ -185,5 +192,8 @@ class AuditingReport < Report
       end
     end
     formatted.join(' | ')
+  end
+
+  def completed_service_formatter
   end
 end


### PR DESCRIPTION
Add `one_time_fee == true` filter to prevent per-patient-per-visit services from showing up in the study-level services auditing report. 

Also, add additional columns 'Quantity of Each Service Completed',  'What was the Charge', and 'Who was the payer (R or T)'.

[Pivotal Story](https://www.pivotaltracker.com/story/show/183606503)

[#183606503]

