### PR TITLE
re-renders appointments#show after procedure deletion. logic was work…

### DIFF
--- a/app/controllers/procedures_controller.rb
+++ b/app/controllers/procedures_controller.rb
@@ -90,6 +90,7 @@ class ProceduresController < ApplicationController
     respond_to :js
 
     @procedure.destroy
+    render 'appointments/show'
   end
 
   def change_procedure_position


### PR DESCRIPTION
Fixes issue where a new procedure is added after all others are completed. When new procedure is deleted, appointment is unable to be completed. Logic was all working correctly, but appointment.complete-visit button was not being re-rendered to update.

[#183986270]

https://www.pivotaltracker.com/n/projects/1304306