### PR TITLE
GM - Combine klok db into fulfillment 

### DIFF
--- a/app/models/klok_project.rb
+++ b/app/models/klok_project.rb
@@ -21,8 +21,8 @@
 class KlokProject < ApplicationRecord
   self.primary_key = 'project_id'
 
-  belongs_to :parent_project, foreign_key: :parent_id
-  has_many :child_projects, foreign_key: :parent_id
+  belongs_to :parent_project, class_name: 'KlokProject', foreign_key: :parent_id
+  has_many :child_projects, class_name: 'KlokProject', foreign_key: :parent_id
   has_many :klok_entries, foreign_key: :project_id
   has_many :klok_people, foreign_key: :resource_id, through: :klok_entries
 


### PR DESCRIPTION
I was trying to clean up the association methods and didn't realize class_name option is needed since we have parent/child virtual relationships on KlokProject. 
It is now tested and working with the class_name declarations back in. 

This reverts commit 4557a91803b10e86984d26552a14f96b1ff59e78.

[Story](https://www.pivotaltracker.com/story/show/180150005)
[#180150005]