### PR TITLE
Participant Tracker Services Dropdown Menu Collapsing after Completing/Incompleting Services

### DIFF
--- a/app/views/multiple_procedures/update_procedures.js.coffee
+++ b/app/views/multiple_procedures/update_procedures.js.coffee
@@ -39,15 +39,10 @@ invoiced_date_time_picker = $("#procedure<%= procedure.id%>InvoicedDatePicker")
 date_time_picker.datetimepicker('date', null)
 date_time_picker.datetimepicker('disable')
 
-$('#core<%= procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
-
 <% elsif procedure.complete? %>
 date_time_picker.datetimepicker('date', "<%= format_date(procedure.completed_date) %>")
 date_time_picker.datetimepicker('enable')
 
-$('#core<%= procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
 <% end %>
 <% end %>
 

--- a/app/views/procedures/update.js.coffee
+++ b/app/views/procedures/update.js.coffee
@@ -61,22 +61,18 @@ $("#procedure<%= @procedure.id %>StatusButtons").data("selected", "incomplete")
 $("#procedure<%= @procedure.id %>StatusButtons button").removeClass("active")
 $("#procedure<%= @procedure.id %>StatusButtons .incomplete-btn").addClass("active")
 performer_selectpicker.selectpicker('val', '<%= @procedure.performer_id %>')
-$('#core<%= @procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= @procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
 
 <% elsif @procedure.complete? && !@procedure.invoiced? %>
 date_time_picker.datetimepicker('date', "<%= format_date(@procedure.completed_date) %>")
 
 date_time_picker.datetimepicker('enable')
 performer_selectpicker.selectpicker('val', '<%= @procedure.performer_id %>')
-$('#core<%= @procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= @procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
 
 <% end %>
 
 <% if @invoiced_or_credited_changed || (@billing_type_updated && @appointment_style == "grouped") %>
 $('#core<%= @procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= @procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
+
 <% end %>
 
 <% if @billing_type_updated %>


### PR DESCRIPTION
I made changes to procedures table while working on '[Add invoiced flag date](https://www.pivotaltracker.com/story/show/176245080)' story that causes table to refresh whenever user changes procedure status. This reverts back to how users are used to it working, but requires user to manually refresh the page to see any changes made to Invoiced toggle.


[Story](https://www.pivotaltracker.com/story/show/185032907)
[#185032907]