### PR TITLE
Participant Tracker Services Dropdown Menu Collapsing after Completing/Incompleting Services

### DIFF
--- a/app/helpers/procedures_helper.rb
+++ b/app/helpers/procedures_helper.rb
@@ -63,7 +63,7 @@ module ProceduresHelper
   end
 
   def procedure_invoiced_display(procedure)
-    disabled = !procedure.appointment.started? || !procedure.complete? || procedure.invoiced? || procedure.credited?
+    disabled = !procedure.complete? || procedure.invoiced? || procedure.credited?
     tooltip =
       if !procedure.appointment.started?
         t('procedures.tooltips.unstarted_appointment')
@@ -80,7 +80,7 @@ module ProceduresHelper
     if current_identity.billing_manager_protocols.include?(procedure.protocol)
       form_for procedure, url: appointment_procedure_path(procedure, appointment_id: procedure.appointment_id), remote: true, method: :put do |f|
         content_tag :div, class: 'tooltip-wrapper', title: tooltip, data: { toggle: 'tooltip' } do
-          f.check_box :invoiced, disabled: disabled, onchange: "Rails.fire(this.form, 'submit')", class: ['btn btn-light', disabled ? 'disabled' : ''], data: { toggle: 'toggle', id: procedure.id, on: t('constants.yes_select'), off: t('constants.no_select') }
+          f.check_box :invoiced, disabled: disabled, onchange: "Rails.fire(this.form, 'submit')", data: { toggle: 'toggle', id: procedure.id, on: t('constants.yes_select'), off: t('constants.no_select'), class: 'invoice_toggle' }
         end
       end
     else
@@ -119,6 +119,8 @@ module ProceduresHelper
       form_for procedure, url: appointment_procedure_path(procedure, appointment_id: procedure.appointment_id), remote: true, method: :put do |f|
         content_tag :div, class: 'tooltip-wrapper', title: tooltip, data: { toggle: 'tooltip' } do
           f.check_box :credited, disabled: disabled, onchange: "Rails.fire(this.form, 'submit')", class: ['btn btn-light', disabled ? 'disabled' : ''], data: { toggle: 'toggle', id: procedure.id, on: t('constants.yes_select'), off: t('constants.no_select') }
+
+          #content_tag(:input, '', type: "checkbox", name: "invoiced", checked: procedure.invoiced?, data: {toggle: 'toggle', on: t('constants.yes_select'), off: t('constants.no_select'), id: procedure.id}, disabled: procedure.invoiced? || procedure.credited? || !procedure.complete?, class: 'invoice_toggle')
         end
       end
     else

--- a/app/helpers/procedures_helper.rb
+++ b/app/helpers/procedures_helper.rb
@@ -119,8 +119,6 @@ module ProceduresHelper
       form_for procedure, url: appointment_procedure_path(procedure, appointment_id: procedure.appointment_id), remote: true, method: :put do |f|
         content_tag :div, class: 'tooltip-wrapper', title: tooltip, data: { toggle: 'tooltip' } do
           f.check_box :credited, disabled: disabled, onchange: "Rails.fire(this.form, 'submit')", class: ['btn btn-light', disabled ? 'disabled' : ''], data: { toggle: 'toggle', id: procedure.id, on: t('constants.yes_select'), off: t('constants.no_select') }
-
-          #content_tag(:input, '', type: "checkbox", name: "invoiced", checked: procedure.invoiced?, data: {toggle: 'toggle', on: t('constants.yes_select'), off: t('constants.no_select'), id: procedure.id}, disabled: procedure.invoiced? || procedure.credited? || !procedure.complete?, class: 'invoice_toggle')
         end
       end
     else

--- a/app/views/multiple_procedures/update_procedures.js.coffee
+++ b/app/views/multiple_procedures/update_procedures.js.coffee
@@ -34,20 +34,13 @@ $("#procedure<%= procedure.id %>StatusButtons .<%= procedure.status %>-btn").add
 updateNotesBadge("procedure<%= procedure.id %>", "<%= procedure.notes.count %>")
 $(".performer #edit_procedure_<%= procedure.id %> .selectpicker").selectpicker('val', '<%= procedure.performer_id %>')
 date_time_picker = $("#procedure<%= procedure.id %>CompletedDatePicker")
-invoiced_date_time_picker = $("#procedure<%= procedure.id%>InvoicedDatePicker")
+
 <% if procedure.incomplete? %>
 date_time_picker.datetimepicker('date', null)
 date_time_picker.datetimepicker('disable')
-
-$('#core<%= procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
-
 <% elsif procedure.complete? %>
 date_time_picker.datetimepicker('date', "<%= format_date(procedure.completed_date) %>")
 date_time_picker.datetimepicker('enable')
-
-$('#core<%= procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
 <% end %>
 <% end %>
 

--- a/app/views/procedures/update.js.coffee
+++ b/app/views/procedures/update.js.coffee
@@ -47,7 +47,6 @@ invoiced_date_time_picker.datetimepicker('date', "<%= format_date(@procedure.inv
 $("#core-<%= @procedure.sparc_core_id %>-procedures").bootstrapTable('refresh', silent: true)
 $('input.invoice_toggle').bootstrapToggle()
 $('input.credit_toggle').bootstrapToggle()
-#$("#modalContainer").modal('hide')
 date_time_picker = $("#procedure<%= @procedure.id %>CompletedDatePicker")
 date_time_picker.datetimepicker('date', "<%= format_date(@procedure.completed_date) %>")
 invoiced_date_time_picker = $("#procedure<%= @procedure.id %>InvoicedDatePicker")

--- a/app/views/procedures/update.js.coffee
+++ b/app/views/procedures/update.js.coffee
@@ -45,8 +45,8 @@ invoiced_date_time_picker.datetimepicker('date', "<%= format_date(@procedure.inv
 
 <% else %>
 $("#core-<%= @procedure.sparc_core_id %>-procedures").bootstrapTable('refresh', silent: true)
-$('input.invoice_toggle').bootstrapToggle()
-$('input.credit_toggle').bootstrapToggle()
+#$('input.invoice_toggle').bootstrapToggle()
+#$('input.credit_toggle').bootstrapToggle()
 date_time_picker = $("#procedure<%= @procedure.id %>CompletedDatePicker")
 date_time_picker.datetimepicker('date', "<%= format_date(@procedure.completed_date) %>")
 invoiced_date_time_picker = $("#procedure<%= @procedure.id %>InvoicedDatePicker")
@@ -65,8 +65,8 @@ performer_selectpicker.selectpicker('val', "")
 invoiced_toggle.bootstrapToggle('disable')
 invoiced_toggle.find('#procedure_invoiced').removeAttr('disabled')
 credited_toggle.bootstrapToggle('disable')
-credited_toggle.find('#procedure_invoiced').removeAttr('disabled')
-$('label[for="edit_procedure_<%= @procedure.id %>"].toggle-off').text('No')
+credited_toggle.find('#procedure_credited').removeAttr('disabled')
+$('.toggle-off').text('No')
 
 <% elsif @procedure.incomplete? %>
 $("#modalContainer").modal('hide')
@@ -80,8 +80,8 @@ performer_selectpicker.selectpicker('val', '<%= @procedure.performer_id %>')
 invoiced_toggle.bootstrapToggle('disable')
 invoiced_toggle.find('#procedure_invoiced').removeAttr('disabled')
 credited_toggle.bootstrapToggle('disable')
-credited_toggle.find('#procedure_invoiced').removeAttr('disabled')
-$('label[for="edit_procedure_<%= @procedure.id %>"].toggle-off').text('No')
+credited_toggle.find('#procedure_credited').removeAttr('disabled')
+$('.toggle-off').text('No')
 
 <% elsif @procedure.complete? && !@procedure.invoiced? %>
 date_time_picker.datetimepicker('date', "<%= format_date(@procedure.completed_date) %>")
@@ -89,8 +89,10 @@ date_time_picker.datetimepicker('enable')
 performer_selectpicker.selectpicker('val', '<%= @procedure.performer_id %>')
 
 invoiced_toggle.bootstrapToggle('enable')
+invoiced_toggle.find('#procedure_invoiced').removeAttr('disabled')
 credited_toggle.bootstrapToggle('enable')
-$('label[for="edit_procedure_<%= @procedure.id %>"].toggle-off').text('No')
+credited_toggle.find('#procedure_credited').removeAttr('disabled')
+$('.toggle-off').text('No')
  <% end %>
 
 <% if (@billing_type_updated && @appointment_style == "grouped") ||  @invoiced_or_credited_changed %>

--- a/app/views/procedures/update.js.coffee
+++ b/app/views/procedures/update.js.coffee
@@ -45,8 +45,6 @@ invoiced_date_time_picker.datetimepicker('date', "<%= format_date(@procedure.inv
 
 <% else %>
 $("#core-<%= @procedure.sparc_core_id %>-procedures").bootstrapTable('refresh', silent: true)
-#$('input.invoice_toggle').bootstrapToggle()
-#$('input.credit_toggle').bootstrapToggle()
 date_time_picker = $("#procedure<%= @procedure.id %>CompletedDatePicker")
 date_time_picker.datetimepicker('date', "<%= format_date(@procedure.completed_date) %>")
 invoiced_date_time_picker = $("#procedure<%= @procedure.id %>InvoicedDatePicker")

--- a/app/views/procedures/update.js.coffee
+++ b/app/views/procedures/update.js.coffee
@@ -38,20 +38,36 @@ $("[name='procedure[notes_attributes][0][<%= attr.to_s %>]']").parents('.form-gr
 <% @procedure.reload %>
 Swal.fire("<%= @cost_error_message %>")
 date_time_picker = $("#procedure<%= @procedure.id %>CompletedDatePicker")
+invoiced_date_time_picker = $("#procedure<%= @procedure.id %>InvoicedDatePicker")
 date_time_picker.datetimepicker('date', "<%= format_date(@procedure.completed_date) %>")
+invoiced_date_time_picker.datetimepicker('date', "<%= format_date(@procedure.invoiced_date) %>")
 <% end %>
 
 <% else %>
 $("#core-<%= @procedure.sparc_core_id %>-procedures").bootstrapTable('refresh', silent: true)
-
+$('input.invoice_toggle').bootstrapToggle()
+$('input.credit_toggle').bootstrapToggle()
+#$("#modalContainer").modal('hide')
 date_time_picker = $("#procedure<%= @procedure.id %>CompletedDatePicker")
+date_time_picker.datetimepicker('date', "<%= format_date(@procedure.completed_date) %>")
+invoiced_date_time_picker = $("#procedure<%= @procedure.id %>InvoicedDatePicker")
+invoiced_date_time_picker.datetimepicker('date', "<%= format_date(@procedure.invoiced_date) %>")
 performer_selectpicker = $(".performer #edit_procedure_<%= @procedure.id %> .selectpicker")
+
+invoiced_toggle = $(".invoiced #edit_procedure_<%= @procedure.id %>")
+credited_toggle = $(".credited #edit_procedure_<%= @procedure.id %>")
 
 <% if @procedure.unstarted? || @procedure.follow_up? %>
 date_time_picker.datetimepicker('date', null)
 date_time_picker.datetimepicker('disable')
 $(".procedure[data-id='<%= @procedure.id %>']").find(".status label.active").removeClass("active")
 performer_selectpicker.selectpicker('val', "")
+
+invoiced_toggle.bootstrapToggle('disable')
+invoiced_toggle.find('#procedure_invoiced').removeAttr('disabled')
+credited_toggle.bootstrapToggle('disable')
+credited_toggle.find('#procedure_invoiced').removeAttr('disabled')
+$('label[for="edit_procedure_<%= @procedure.id %>"].toggle-off').text('No')
 
 <% elsif @procedure.incomplete? %>
 $("#modalContainer").modal('hide')
@@ -61,22 +77,25 @@ $("#procedure<%= @procedure.id %>StatusButtons").data("selected", "incomplete")
 $("#procedure<%= @procedure.id %>StatusButtons button").removeClass("active")
 $("#procedure<%= @procedure.id %>StatusButtons .incomplete-btn").addClass("active")
 performer_selectpicker.selectpicker('val', '<%= @procedure.performer_id %>')
-$('#core<%= @procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= @procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
+
+invoiced_toggle.bootstrapToggle('disable')
+invoiced_toggle.find('#procedure_invoiced').removeAttr('disabled')
+credited_toggle.bootstrapToggle('disable')
+credited_toggle.find('#procedure_invoiced').removeAttr('disabled')
+$('label[for="edit_procedure_<%= @procedure.id %>"].toggle-off').text('No')
 
 <% elsif @procedure.complete? && !@procedure.invoiced? %>
 date_time_picker.datetimepicker('date', "<%= format_date(@procedure.completed_date) %>")
-
 date_time_picker.datetimepicker('enable')
 performer_selectpicker.selectpicker('val', '<%= @procedure.performer_id %>')
-$('#core<%= @procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= @procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
 
-<% end %>
+invoiced_toggle.bootstrapToggle('enable')
+credited_toggle.bootstrapToggle('enable')
+$('label[for="edit_procedure_<%= @procedure.id %>"].toggle-off').text('No')
+ <% end %>
 
-<% if @invoiced_or_credited_changed || (@billing_type_updated && @appointment_style == "grouped") %>
+<% if (@billing_type_updated && @appointment_style == "grouped") ||  @invoiced_or_credited_changed %>
 $('#core<%= @procedure.core.id %>ProceduresGroupedView').bootstrapTable('refresh', silent: true)
-$('#core<%= @procedure.core.id %>ProceduresCustomView').bootstrapTable('refresh', silent: true)
 <% end %>
 
 <% if @billing_type_updated %>


### PR DESCRIPTION
This pull request enables/disables invoiced and credited toggles when procedure status is updated, without refreshing the whole table or page. 

[Story](https://www.pivotaltracker.com/story/show/185032907)
[#185032907]