### PR TITLE
Enable/disable invoiced/credited toggles on multiple procedure update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   # ####
   - rvm use $(< .ruby-version) --install --binary --fuzzy
   - export BUNDLE_GEMFILE=$PWD/Gemfile
-  - gem install bundler
+  - gem install bundler -v 2.4.22
   - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
   - cp config/database.yml.example config/database.yml
   - cp config/fulfillment_db.yml.example config/fulfillment_db.yml

--- a/app/views/multiple_procedures/update_procedures.js.coffee
+++ b/app/views/multiple_procedures/update_procedures.js.coffee
@@ -35,13 +35,31 @@ updateNotesBadge("procedure<%= procedure.id %>", "<%= procedure.notes.count %>")
 $(".performer #edit_procedure_<%= procedure.id %> .selectpicker").selectpicker('val', '<%= procedure.performer_id %>')
 date_time_picker = $("#procedure<%= procedure.id %>CompletedDatePicker")
 
+invoiced_date_time_picker = $("#procedure<%= procedure.id %>InvoicedDatePicker")
+invoiced_date_time_picker.datetimepicker('date', "<%= format_date(procedure.invoiced_date) %>")
+
+invoiced_toggle = $(".invoiced #edit_procedure_<%= procedure.id %>")
+credited_toggle = $(".credited #edit_procedure_<%= procedure.id %>")
+
 <% if procedure.incomplete? %>
 date_time_picker.datetimepicker('date', null)
 date_time_picker.datetimepicker('disable')
 
+invoiced_toggle.bootstrapToggle('disable')
+invoiced_toggle.find('#procedure_invoiced').removeAttr('disabled')
+credited_toggle.bootstrapToggle('disable')
+credited_toggle.find('#procedure_credited').removeAttr('disabled')
+$('.toggle-off').text('No')
+
 <% elsif procedure.complete? %>
 date_time_picker.datetimepicker('date', "<%= format_date(procedure.completed_date) %>")
 date_time_picker.datetimepicker('enable')
+
+invoiced_toggle.bootstrapToggle('enable')
+invoiced_toggle.find('#procedure_invoiced').removeAttr('disabled')
+credited_toggle.bootstrapToggle('enable')
+credited_toggle.find('#procedure_credited').removeAttr('disabled')
+$('.toggle-off').text('No')
 
 <% end %>
 <% end %>

--- a/spec/features/participants/participant_tracker/identity_creates_participant_notes_spec.rb
+++ b/spec/features/participants/participant_tracker/identity_creates_participant_notes_spec.rb
@@ -82,6 +82,7 @@ feature 'User views the participant tracker page', js: true do
     wait_for_ajax
     first('.dropdown-menu.show span.text', text: @protocol.arms.second.name).click
     wait_for_ajax
+    sleep 2
   end
 
   def then_i_should_see_the_notes_modal

--- a/spec/support/features/visit_helpers.rb
+++ b/spec/support/features/visit_helpers.rb
@@ -36,7 +36,7 @@ module Features
     def given_i_am_viewing_a_visit
       visit calendar_protocol_participant_path(id: @protocols_participant.id, protocol_id: @protocol)
       wait_for_ajax
-      
+      sleep 2
       first('a.list-group-item.appointment-link').click
       wait_for_ajax
     end
@@ -47,7 +47,7 @@ module Features
 
       first('a.list-group-item.appointment-link').click
       wait_for_ajax
-      
+
       find('a.btn.start-appointment').click
       wait_for_ajax
     end


### PR DESCRIPTION
We added functionality for enabling and disabling the invoiced and credited toggles upon status update without collapsing the list of grouped procedures. This is a followup that adds the same functionality when using the multiple procedure selectpicker to change statuses. 

[Story](https://www.pivotaltracker.com/story/show/185032907)
[#185032907]