### PR TITLE
Auto sort fulfillments by created_at

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   # ####
   - rvm use $(< .ruby-version) --install --binary --fuzzy
   - export BUNDLE_GEMFILE=$PWD/Gemfile
-  - gem install bundler
+  - gem install bundler -v 2.4.22
   - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
   - cp config/database.yml.example config/database.yml
   - cp config/fulfillment_db.yml.example config/fulfillment_db.yml

--- a/app/controllers/fulfillments_controller.rb
+++ b/app/controllers/fulfillments_controller.rb
@@ -27,7 +27,7 @@ class FulfillmentsController < ApplicationController
     respond_to do |format|
       format.js { render }
       format.json {
-        @fulfillments = @line_item.fulfillments.includes(:notes)
+        @fulfillments = @line_item.fulfillments.includes(:notes).order(fulfilled_at: :desc, created_at: :desc)
 
         render
       }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186301230

Non Clinical (one time fee) services are sorting by descnding fulfilled_at date and then created_at date in ascending order. It would be most helpful to service providers for these to sort by descending fulfilled_at date AND descending created_at date to better track workflows based on latest entry data.

*Acceptance Criteria*
- [x] Non-clinical (one time fee) fulfillments sort by descending fulfillment date and then descending created_at date.