### PR TITLE
Fulfillment invoice calendar popup cutoff if only one fulfillment bug

### DIFF
--- a/app/assets/stylesheets/study_level_activities.sass
+++ b/app/assets/stylesheets/study_level_activities.sass
@@ -52,4 +52,4 @@ td.wrap
   width: 95px
 
 .modal-body.table-responsive.fulfillments-list-modal
-  min-height: 50vh
+  min-height: 80vh


### PR DESCRIPTION
When there is only one fulfillment in the Fulfillment table of a service (and it is invoiced), the "Invoiced Date" calendar pop-up gets cutoff.

Acceptance Criteria:
The "Invoiced Date" calendar pop-up does not get cutoff when there is only one fulfillment for a service

https://www.pivotaltracker.com/story/show/186802623