### PR TITLE
Add participant visit start/end times

### DIFF
--- a/app/views/multiple_procedures/_complete_all_select.html.haml
+++ b/app/views/multiple_procedures/_complete_all_select.html.haml
@@ -22,7 +22,7 @@
   - disabled = !appointment.started? || appointment.completed? ? 'disabled' : nil
   .w-60
     = select_tag "core_#{core_id}_multiselect", options_for_select(procedures_groups_for_select(procedures)), disabled: disabled, class: 'core_multiselect selectpicker show-tick w-100', multiple: true, data: { actions_box: true, appointment_id: appointment.id, core_id: core_id }
-  %button.btn.btn-default.btn-primary.multiselect.complete-all{ type: 'button', id: "core_#{core_id}_multiselect_complete_all", disabled: disabled, class: "w-20 #{disabled}", data: { status: 'complete' } }
+  %button.btn.btn-default.btn-primary.multiselect.complete-all{ type: 'button', id: "core_#{core_id}_multiselect_complete_all", disabled: disabled, class: "w-30 #{disabled}", data: { status: 'complete' } }
     = t('multiple_procedures_modal.complete_all')
-  %button.btn.btn-default.btn-warning.multiselect.incomplete-all{ type: 'button', id: "core_#{core_id}_multiselect_incomplete_all", disabled: disabled, class: "w-20 #{disabled}", data: { status: 'incomplete' } }
+  %button.btn.btn-default.btn-warning.multiselect.incomplete-all{ type: 'button', id: "core_#{core_id}_multiselect_incomplete_all", disabled: disabled, class: "w-30 #{disabled}", data: { status: 'incomplete' } }
     = t('multiple_procedures_modal.incomplete_all')

--- a/app/views/procedure_groups/_form.html.haml
+++ b/app/views/procedure_groups/_form.html.haml
@@ -1,5 +1,5 @@
 .w-100
-  - disabled = !appointment.started? || appointment.completed? ? 'disabled' : nil
+  - disabled = !appointment.started? ? 'disabled' : nil
   .row
     .col
       .tooltip-wrapper{ title: t('procedure_groups.start_time'), data: { toggle: disabled ? 'tooltip' : '' } }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -552,8 +552,8 @@ en:
       group_invoiced_warning:  "This group of procedures have been invoiced and cannot be altered."
 
   procedure_groups:
-    start_time: "Set Core Procedure Group Start Time"
-    end_time: "Set Core Procedure Group End Time"
+    start_time: "Enter Procedures Start Time"
+    end_time: "Enter Procedures End Time"
     flash_messages:
       updated: "Core Procedure Group Time Updated"
 


### PR DESCRIPTION
To help track when patients are occupying rooms during a visit, Nexus has requested start/end times be added to participant visits

https://www.pivotaltracker.com/story/show/186301263