### PR TITLE
Update ```bundle install``` command in travis script according to bundler deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ services:
 before_install:
   - "export TZ=America/New_York"
   - nvm install node 14.19.2
+  - bundle config --local deployment 'true'
+  - bundle config --local path 'vendor/bundle'
 before_script:
   - "export DISPLAY=:99.0"
   # CWF Config
@@ -32,7 +34,7 @@ before_script:
   - rvm use $(< .ruby-version) --install --binary --fuzzy
   - export BUNDLE_GEMFILE=$PWD/Gemfile
   - gem install bundler -v 2.4.22
-  - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
+  - bundle install --jobs=3 --retry=3
   - cp config/database.yml.example config/database.yml
   - cp config/fulfillment_db.yml.example config/fulfillment_db.yml
   # - cp config/epic.yml.example config/epic.yml


### PR DESCRIPTION
``` $ bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}  ```

>[DEPRECATED] The --deployment flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set --local deployment 'true', and stop using this flag 

>[DEPRECATED] The --path flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set --local path 'vendor/bundle', and stop using this flag