### PR TITLE
Participant service rates not showing modified rates

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -72,11 +72,9 @@ class LineItem < ApplicationRecord
   end
 
   def cost(funding_source = protocol.sparc_funding_source, date = Time.current)
-    if admin_rates.any? && admin_rates.last.updated_at <= date
-      admin_rates.last.admin_cost
-    else
-      service.cost(funding_source, date)
-    end
+    return current_admin_rate(date) if current_admin_rate_applicable?(date)
+    return old_admin_rate(funding_source, date) if admin_rate_changes.any?
+    service.cost(funding_source, date)
   end
 
   def name=(n)
@@ -118,5 +116,23 @@ class LineItem < ApplicationRecord
   end
 
   private
+
+  def current_admin_rate_applicable?(date)
+    admin_rates.any? && admin_rates.last.created_at.to_date <= date.to_date
+  end
+
+  def current_admin_rate(date)
+    admin_rates.last.admin_cost
+  end
+
+  def old_admin_rate(funding_source, date)
+    cost_when_fulfilled = applicable_old_admin_rate(date)
+    return cost_when_fulfilled.admin_cost if cost_when_fulfilled && !cost_when_fulfilled.cost_reset
+    service.cost(funding_source, date)
+  end
+
+  def applicable_old_admin_rate(date)
+    admin_rate_changes.where("DATE(date_of_change) <= ?", date.to_date).order("date_of_change DESC").first
+  end
 
 end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -216,6 +216,8 @@ class Procedure < ApplicationRecord
     self.procedure_group&.end_time
   end
 
+  private
+
   def admin_rate
     protocol.sparc_protocol.service_requests
     .flat_map(&:sub_service_requests)
@@ -232,11 +234,23 @@ class Procedure < ApplicationRecord
     line_item&.admin_rate_changes if line_item
   end
 
-  def had_admin_rate_at_time_of_completion
-    old_admin_rates.any? { |old_admin_rate| old_admin_rate.created_at > completed_date } if old_admin_rates
+  def new_cost(funding_source, date)
+    return visit.line_item.cost(funding_source, date).to_i if visit
+    return check_current_admin_rate(date) if admin_rate
+    return check_old_admin_rates(funding_source, date) if old_admin_rates.any?
+    service.cost(funding_source, date)
   end
 
-  private
+  def check_current_admin_rate(date)
+    return admin_rate.admin_cost if admin_rate.created_at.to_date <= date.to_date
+    check_old_admin_rates(funding_source, date)
+  end
+
+  def check_old_admin_rates(funding_source, date)
+    cost_when_completed = old_admin_rates.where("DATE(date_of_change) <= ?", date.to_date).order("date_of_change DESC").first
+    return cost_when_completed.admin_cost if cost_when_completed && !cost_when_completed.cost_reset
+    service.cost(funding_source, date).to_i
+  end
 
   def update_protocols_participant_deletable
     protocols_participant.update(deletable: !protocols_participant.procedures.exists?(status: ['follow_up', 'incomplete', 'complete'])) if protocols_participant
@@ -256,16 +270,6 @@ class Procedure < ApplicationRecord
 
     if cost.nil?
       errors[:service_cost] << "No cost found, ensure that a valid pricing map exists for that date."
-    end
-  end
-
-  def new_cost(funding_source, date)
-    if visit
-      visit.line_item.cost(funding_source, date).to_i
-    elsif admin_rate && admin_rate.created_at <= date
-      admin_rate.admin_cost
-    else
-      service.cost(funding_source, date).to_i
     end
   end
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -231,7 +231,7 @@ class Procedure < ApplicationRecord
     .flat_map(&:sub_service_requests)
     .flat_map(&:line_items)
     .find { |line_item| line_item.service_id == service.id }
-    line_item&.admin_rate_changes if line_item
+    line_item&.admin_rate_changes || []
   end
 
   def new_cost(funding_source, date)

--- a/lib/reports/invoice_report.rb
+++ b/lib/reports/invoice_report.rb
@@ -32,25 +32,13 @@ class InvoiceReport < Report
   end
 
   def display_pppv_modified_rate_column(procedure)
-    admin_rates = procedure.visit&.line_item&.admin_rates
-    service_cost = procedure.service.cost(procedure.protocol.sparc_funding_source, procedure.completed_date)
-    modified = "No"
-    if admin_rates&.any?
-      modified = "Yes" if admin_rates&.last&.updated_at < procedure.completed_date
-    elsif procedure.admin_rate
-      modified = "Yes" if procedure.admin_rate.created_at < procedure.completed_date && service_cost != procedure.service_cost
-    elsif procedure.had_admin_rate_at_time_of_completion
-      modified = "Yes" if service_cost != procedure.service_cost
-    end
-    modified
+    modified = procedure.service_cost != procedure.service.cost(procedure.protocol.sparc_funding_source, procedure.completed_date)
+    modified ? "Yes" : "No"
   end
 
   def display_otf_modified_rate_column(fulfillment)
-    fulfillment.line_item.admin_rates.reload
-    line_item = fulfillment.line_item
-    admin_rate = line_item.admin_rates.last
-    fulfilled_at_from_db = fulfillment.read_attribute(:fulfilled_at)
-    admin_rate && admin_rate.updated_at < fulfilled_at_from_db ? "Yes" : "No"
+    modified = fulfillment.service_cost != fulfillment.line_item.service.cost(fulfillment.protocol.sparc_funding_source, fulfillment.fulfilled_at)
+    modified ? "Yes" : "No"
   end
 
   def display_subsidy_percent(object)

--- a/spec/factories/admin_rate.rb
+++ b/spec/factories/admin_rate.rb
@@ -1,0 +1,27 @@
+# Copyright © 2011-2023 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+FactoryBot.define do
+  factory :admin_rate do
+    admin_cost { 100 }
+    updated_at { Date.today }
+    line_item
+  end
+end

--- a/spec/factories/admin_rate_change.rb
+++ b/spec/factories/admin_rate_change.rb
@@ -1,0 +1,28 @@
+# Copyright © 2011-2023 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+FactoryBot.define do
+  factory :admin_rate_change do
+    admin_cost { 100 }
+    updated_at { Date.yesterday }
+    cost_reset { false }
+    line_item
+  end
+end

--- a/spec/models/fulfillment_spec.rb
+++ b/spec/models/fulfillment_spec.rb
@@ -50,8 +50,53 @@ RSpec.describe Fulfillment, type: :model do
         expect(fulfillment.quantity_type).to eq(line_item.quantity_type)
       end
     end
-  end
 
+    describe '.service_cost' do
+      context 'line item has no current or historical effective admin rates' do
+        it 'should return the service cost' do
+          line_item = create(:line_item, protocol: create(:protocol), service: create(:service))
+          fulfillment = create(:fulfillment, line_item: line_item)
+          fulfillment.fulfilled_at = (Time.now).strftime("%m/%d/%Y")
+          fulfillment.send(:recalculate_cost)
+          expect(fulfillment.service_cost).to eq(line_item.cost)
+        end
+      end
+
+      context 'line item has an effective admin rate' do
+        it 'should return the modified cost of the service' do
+          line_item = create(:line_item, protocol: create(:protocol), service: create(:service))
+          admin_rate = create(:admin_rate, line_item: line_item, admin_cost: 100)
+          fulfillment = create(:fulfillment, fulfilled_at: Time.current.strftime("%m/%d/%Y"), line_item: line_item)
+          fulfillment.fulfilled_at = (Time.now + 1.day).strftime("%m/%d/%Y")
+          fulfillment.send(:recalculate_cost)
+          expect(fulfillment.service_cost).to eq(line_item.cost)
+        end
+      end
+
+      context 'line item has effective old admin rate with no cost_reset flag' do
+        it 'should return the modified cost of the service' do
+          line_item = create(:line_item, protocol: create(:protocol), service: create(:service))
+          old_admin_rate = create(:admin_rate_change, line_item: line_item, admin_cost: 100)
+          fulfillment = create(:fulfillment, fulfilled_at: Time.current.strftime("%m/%d/%Y"), line_item: line_item)
+          fulfillment.fulfilled_at = (Time.now + 1.day).strftime("%m/%d/%Y")
+          fulfillment.send(:recalculate_cost)
+          expect(fulfillment.service_cost).to eq(line_item.cost)
+        end
+      end
+
+      context 'line item has effective old admin rate with cost_reset flag set' do
+        it 'should return service cost' do
+          line_item = create(:line_item, protocol: create(:protocol), service: create(:service))
+          old_admin_rate = create(:admin_rate_change, line_item: line_item, admin_cost: 100, cost_reset: true)
+          # old_admin_rate.update_attributes(cost_reset: true)
+          fulfillment = create(:fulfillment, fulfilled_at: Time.current.strftime("%m/%d/%Y"), line_item: line_item)
+          fulfillment.fulfilled_at = (Time.now + 1.day).strftime("%m/%d/%Y")
+          fulfillment.send(:recalculate_cost)
+          expect(fulfillment.service_cost).to eq(line_item.service.cost)
+        end
+      end
+    end
+  end
 
   context 'invoiced flag set to true' do
     describe 'invoiced_date set' do

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe LineItem, type: :model do
   it { is_expected.to have_many(:documents) }
   it { is_expected.to have_many(:components) }
 
+  it { is_expected.to have_many(:admin_rates) }
+  it { is_expected.to have_many(:admin_rate_changes) }
+
   context 'validations' do
 
     it { is_expected.to validate_presence_of(:protocol_id) }


### PR DESCRIPTION
First check admin_rates table for an existing record and, if it was created on or before the day of fufillment, use it. If not, check admin_rate_changes for the latest record on or before date of fulfillment and, if its cost_reset flag is false, use it. For everything else, use Service#cost.