### PR TITLE
Invoice Report Mod Rate Column Not Accurate for Incorrect Old Prices 

### DIFF
--- a/app/models/concerns/reports_shared_methods.rb
+++ b/app/models/concerns/reports_shared_methods.rb
@@ -28,13 +28,25 @@ module ReportsSharedMethods
   end
 
   def display_pppv_modified_rate_column(procedure)
+    has_admin_rate = false
     admin_rate = procedure.send(:admin_rate)
-    admin_rate && admin_rate.created_at.to_date <= procedure.completed_date.to_date || procedure.send(:old_admin_rates) && procedure.send(:check_old_admin_rates, procedure.completed_date) ? "Yes" : "No"
+    if admin_rate && admin_rate.created_at.to_date <= procedure.completed_date.to_date
+      has_admin_rate = true
+    elsif procedure.send(:old_admin_rates) && procedure.send(:check_old_admin_rates, procedure.completed_date)
+      has_admin_rate = true
+    else
+      has_admin_rate = false
+    end
+    has_admin_rate && (procedure.service.cost(procedure.funding_source, procedure.completed_date).to_i != procedure.service_cost && procedure.service.cost(nil, procedure.completed_date).to_i != procedure.service_cost) ? "Yes" : "No"
   end
 
   def display_otf_modified_rate_column(fulfillment)
     line_item = fulfillment.line_item
-    line_item.send(:current_admin_rate) && line_item.send(:current_admin_rate_applicable?, fulfillment.fulfilled_at) || line_item.send(:old_admin_rates) && line_item.send(:applicable_old_admin_rate, fulfillment.fulfilled_at) ? "Yes" : "No"
+    has_admin_rate = false
+    if line_item.send(:current_admin_rate) && line_item.send(:current_admin_rate_applicable?, fulfillment.fulfilled_at) || line_item.send(:old_admin_rates) && line_item.send(:applicable_old_admin_rate, fulfillment.fulfilled_at)
+      has_admin_rate = true
+    end
+    has_admin_rate && (line_item.service.cost(line_item.protocol.sparc_funding_source, fulfillment.fulfilled_at).to_i != fulfillment.service_cost && line_item.service.cost(nil, fulfillment.fulfilled_at).to_i != fulfillment.service_cost) ? "Yes" : "No"
   end
 
   def display_subsidy_percent(object)


### PR DESCRIPTION
In v3.5.0 we added full support for checking for a modified rate when stamping service_cost on fulfillments. For existing fulfillments that had a modified rate that wasn't accounted for when their cost was set, we want their modified rate column to say "no". This patch achieves that by comparing the cost to the regular pricing map costs before labeling it a modified rate.

https://www.pivotaltracker.com/story/show/187977642