### PR TITLE
Fix deployment issues with Rails 7 on RHEL 7

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -29,6 +29,7 @@ require 'capistrano/passenger'
 require 'capistrano/delayed_job'
 require 'capistrano/rails'
 require "whenever/capistrano"
+require 'capistrano/yarn'
 
 # required to deploy with dotenv
 require 'dotenv'

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'will_paginate'
 gem 'yajl-ruby', require: 'yajl'
 gem 'dalli'
 gem 'progress_bar'
+gem 'nokogiri', '1.15.7', force_ruby_platform: true
 
 group :deploy do
   gem 'capistrano', '~> 3.16'

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :deploy do
   gem 'capistrano-rails', '~> 1.6'
   gem 'capistrano-passenger'
   gem 'capistrano3-delayed-job', '~> 1.7'
+  gem 'capistrano-yarn'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,7 +323,7 @@ GEM
     net-ssh (7.3.0)
     netrc (0.11.0)
     nio4r (2.7.5)
-    nokogiri (1.19.1)
+    nokogiri (1.15.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     omniauth (2.0.4)
@@ -596,6 +596,7 @@ DEPENDENCIES
   microsoft_teams_incoming_webhook_ruby
   mysql2 (= 0.5.6)
   net-ldap
+  nokogiri (= 1.15.7)
   omniauth
   omniauth-rails_csrf_protection
   omniauth-shibboleth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
+    capistrano-yarn (2.0.2)
+      capistrano (~> 3.0)
     capistrano3-delayed-job (1.7.6)
       capistrano (~> 3.0, >= 3.0.0)
       daemons (~> 1.3)
@@ -568,6 +570,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails (~> 1.6)
   capistrano-rvm
+  capistrano-yarn
   capistrano3-delayed-job (~> 1.7)
   capybara
   climate_control

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -46,7 +46,7 @@ set :log_level, :debug
 set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secrets.yml', 'config/sparc_db.yml', 'config/klok_db.yml', '.env')
 
 # Default value for linked_dirs is []
-set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', ENV.fetch('DOCUMENTS_FOLDER'), 'public/system/imports')
+set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', ENV.fetch('DOCUMENTS_FOLDER'), 'public/system/imports', 'node_modules')
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
* Rails 7 pulls in a newer nokogiri that ships precompiled but it's incompatible with the rhel7 on -d so need to compile from source and pin an older version to get it to build

* `yarn install` no longer happening so have to add it explicitly with capistrano-yarn gem

* Symlink node_modules across deploys