### PR TITLE
SPFUL-681: Chrome and Safari Icon broken in homepage footer

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -57,13 +57,13 @@
             = t('layout.footer.browsers.header')
           %ul.list-unstyled.mb-0
             %li.mb-1
-              = image_tag "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Google_Chrome_icon_%28September_2014%29.svg/512px-Google_Chrome_icon_%28September_2014%29.svg.png", alt: "Chrome icon", width: 18
+              = image_tag "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/Google_Chrome_icon_%28March_2011%29.svg/960px-Google_Chrome_icon_%28March_2011%29.svg.png", alt: "Chrome icon", width: 18
               = t('layout.footer.browsers.chrome')
             %li.mb-1
               = image_tag "https://upload.wikimedia.org/wikipedia/commons/7/7a/Firefox_brand_logo%2C_2019.svg", alt: "Firefox icon", width: 18, title: "Mozilla Foundation (MPL 1.1 &lt;https://www.mozilla.org/MPL/1.1/&gt;, GPL &lt;http://www.gnu.org/licenses/gpl.html&gt; or LGPL &lt;http://www.gnu.org/licenses/lgpl.html&gt;), via Wikimedia Commons"
               = t('layout.footer.browsers.firefox')
             %li.mb-1
-              = image_tag "https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/Safari_browser_logo.svg/128px-Safari_browser_logo.svg.png", alt: "Safari icon", width: 18
+              = image_tag "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Safari-icon-1024.png/960px-Safari-icon-1024.png", alt: "Safari icon", width: 18
               = t('layout.footer.browsers.safari')
             %li.mb-1
               = image_tag "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Microsoft_Edge_logo_%282015%E2%80%932019%29.svg/512px-Microsoft_Edge_logo_%282015%E2%80%932019%29.svg.png", alt: "Edge icon", width: 18


### PR DESCRIPTION
Updates image_tags of Chrome and Safari icons in _footer.html.haml.