### PR TITLE
[SPFUL-666] Updates to Finance Billing Report method to account for YAML parser security upggrade

### DIFF
--- a/app/models/concerns/reports_shared_methods.rb
+++ b/app/models/concerns/reports_shared_methods.rb
@@ -101,11 +101,13 @@ module ReportsSharedMethods
       action: "update",
       )
       .order(created_at: :desc)
-      .find { |a| YAML.load(a.audited_changes, aliases: true)["funding_source"] }
-    previous_funding_info = audit ? YAML.load(audit.audited_changes)["funding_source"] : []
+      .find { |a| YAML.unsafe_load(a.audited_changes)["funding_source"] }
+      
+    previous_funding_info = audit ? YAML.unsafe_load(audit.audited_changes)["funding_source"] : []
+    
     {
       previous_funding_source: previous_funding_info.first&.humanize,
-      change_date: audit ?  format_date(audit.created_at) : nil
+      change_date: audit ? format_date(audit.created_at) : nil
     }
   end
 end


### PR DESCRIPTION
In newer versions of Ruby, the underlying YAML parser (Psych 4+) changed "YAML.load" to use "safe_load" by default to prevent remote code execution vulnerabilities. Rails 7 embraced this for any database columns that use ActiveRecord's serialize method. The method that needed to be updated is “get_previous_funding_source” in “app/models/concerns/reports_shared_methods.rb”. ActiveRecord is trying to instantiate an object that has a YAML-serialized column. That column contains an "ActiveSupport::TimeWithZone" object, which Psych rejected because it isn't in the default safe-load allowlist. I've implemented "YAML.unsafe_load" since the data in question comes from SPARC's audit logs and is therefore a trusted source. Audit logs record everything - if we use "safe_load", we might fix the "TimeWithZone" error today... but next month, a user might change a cost field, and the background job will crash again complaining about "BigDecimal". Using unsafe_load treats the data exactly how Ruby 2.x did and prevents this report from being brittle.