### PR TITLE
[SPFUL-683] Updating 'About SPARCRequest' link destination in footer

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -356,7 +356,7 @@ en:
         header: "About"
         about_sparc:
           text: "About SPARCRequest"
-          url: "https://research.musc.edu/resources/sctr/research-resources/tools/sparcrequest"
+          url: "https://research.musc.edu"
         about_sctr:
           text: "About SCTR"
           url: "http://sctr.musc.edu"


### PR DESCRIPTION
Previously linked to a now dead page, updated to 'research.musc.edu'.