### PR TITLE
[SPFUL-684] Deploy and Delayed Jobs Maintenance

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,5 +67,3 @@ namespace :deploy do
     end
   end
 end
-
-after "deploy:restart", "delayed_job:restart"


### PR DESCRIPTION
Removing manual "delayed_jobs:restart" call at the end of the config/deploy.rb, as it is called automatically by Capistrano during deployment. Prior to removal, the deploy log would display a message saying that delayed_jobs:restart had already been triggered and would not be called a second time. With delayed_jobs needing to be manually restarted by the dev team after each deploy in order for jobs to begin processing, this tidies the deploy logs and process while removing the possibility that the duplicate call during deployment was the reason for the jobs not processing.