### PR TITLE
[SPFUL-672] Visible Error Message for Line Item Document Validation

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -62,18 +62,28 @@ class DocumentsController < ApplicationController
     end
   end
 
-  def create
+def create
     respond_to do |format|
       format.js {
-        @document = Document.create(document_params.merge!(original_filename: params[:document][:document].original_filename,
-                                                          title: params[:document][:document].original_filename,
-                                                          content_type: params[:document][:document].content_type,
-                                                          state: "Completed"))
+        @document = Document.new(document_params.merge(
+                                   original_filename: params[:document][:document].original_filename,
+                                   title: params[:document][:document].original_filename,
+                                   content_type: params[:document][:document].content_type,
+                                   state: "Completed"
+                                 ))
 
-        create_document_file
-        @selector = "#{@document.unique_selector}_documents"
+        # Define @documentable out here so it's ALWAYS available to the view
         @documentable = @document.documentable
-        flash.now[:success] = t(:documents)[:flash_messages][:created]
+
+        if @document.save
+          create_document_file
+          @selector = "#{@document.unique_selector}_documents"
+          flash.now[:success] = t(:documents)[:flash_messages][:created]
+        else
+          # Map the model errors to the singular @error string the view expects
+          @errors = @document.errors
+          @error = @document.errors.full_messages.join(', ')
+        end
       }
     end
   end


### PR DESCRIPTION
When uploading a Line Item Document, the validation rules are the same as when a user attempts to create a Report title (Report titles cannot contain a semicolon or comma, and file names for uploaded Line Item Documents cannot contain a semicolon or a comma). This is because Reports and Line Item Documents have always been the same object model in the CWF database (model class “Document”), there has only been one validation method written for this model class, and the model validation written for Report titles has therefore always been applied to the file name for Line Item Documents. The user, however, was never shown any error validation message when uploading a Line Item Document as they have been used to seeing when creating a Report title. They now see that error message. In a subsequent story, we can discuss changing the validation being applied to Line Item Documents (if the validation of not allowing semicolons or commas in the file name seems arbitrary, and we would rather shoot for other special characters or file extensions).